### PR TITLE
Do not render HTML when fetching data with HTTPie

### DIFF
--- a/bin/srv.py
+++ b/bin/srv.py
@@ -225,7 +225,7 @@ def wttr(location = None):
     user_agent = request.headers.get('User-Agent').lower()
 
     html_output = True
-    if 'curl' in user_agent or 'wget' in user_agent:
+    if 'curl' in user_agent or 'wget' in user_agent or 'HTTPie' in user_agent:
         html_output = False
 
     if location == ':help':


### PR DESCRIPTION
[HTTPie](https://github.com/jkbrzt/httpie) is another popular command line HTTP client. This commit / PR make sure HTTPie does not get the HTML output, but instead the console version.
