### PR TITLE
Use environment variables for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ The `City` parameter in `~/.wegorc` is ignored.
 
 ### Configure wttr.in
 
-Edit the `bin/srv.py` and specify the path to the local `wttr.in` installation,
-to the GeoLite database and to the `wego` installation:
+Configure the following environment variables specifing the path to the local `wttr.in`
+installation, to the GeoLite database and to the `wego` installation. For example:
 
-    MYDIR = "/home/igor/wttr.in"
-    GEOLITE = "/home/igor/wttr.in/GeoLite2-City.mmdb"
-    WEGO = "/home/igor/go/bin/wego"
+    WTTR_MYDIR = "/home/igor/wttr.in"
+    WTTR_GEOLITE = "/home/igor/wttr.in/GeoLite2-City.mmdb"
+    WTTR_WEGO = "/home/igor/go/bin/wego"
 
 
 ### Configure HTTP-frontend service

--- a/bin/srv.py
+++ b/bin/srv.py
@@ -22,9 +22,9 @@ patch_all()
 from flask import Flask, request, render_template, send_from_directory
 app = Flask(__name__)
 
-MYDIR = os.path.abspath(os.path.dirname( os.path.dirname('__file__') ))
-GEOLITE = os.path.join( MYDIR, "GeoLite2-City.mmdb" )
-WEGO = "/home/igor/go/bin/wego"
+MYDIR = os.environ.get('WTTR_MYDIR', os.path.abspath(os.path.dirname( os.path.dirname('__file__') )))
+GEOLITE = os.environ.get('WTTR_GEOLITE', os.path.join( MYDIR, "GeoLite2-City.mmdb" ))
+WEGO = os.environ.get('WTTR_WEGO', "/home/igor/go/bin/wego")
 
 CACHEDIR  = os.path.join( MYDIR, "cache" )
 IP2LCACHE = os.path.join( MYDIR, "cache/ip2l" )


### PR DESCRIPTION
Use environment variables for configuration: the script must not be edited.