### PR TITLE
add 'lwp-request' to non-html user agents

### DIFF
--- a/bin/srv.py
+++ b/bin/srv.py
@@ -225,7 +225,7 @@ def wttr(location = None):
     user_agent = request.headers.get('User-Agent').lower()
 
     html_output = True
-    if 'curl' in user_agent or 'wget' in user_agent or 'httpie' in user_agent:
+    if 'curl' in user_agent or 'wget' in user_agent or 'httpie' in user_agent or 'lwp-request' in user_agent:
         html_output = False
 
     if location == ':help':


### PR DESCRIPTION
this should make /usr/bin/GET from libwww perl output plain text instead of HTML like curl or wget already do