### PR TITLE
Added support to configure listen host and port

### DIFF
--- a/bin/srv.py
+++ b/bin/srv.py
@@ -25,6 +25,8 @@ app = Flask(__name__)
 MYDIR = os.environ.get('WTTR_MYDIR', os.path.abspath(os.path.dirname( os.path.dirname('__file__') )))
 GEOLITE = os.environ.get('WTTR_GEOLITE', os.path.join( MYDIR, "GeoLite2-City.mmdb" ))
 WEGO = os.environ.get('WTTR_WEGO', "/home/igor/go/bin/wego")
+LISTEN_HOST = os.environ.get('WTTR_LISTEN_HOST', "127.0.0.1")
+LISTEN_PORT = int(os.environ.get('WTTR_LISTEN_PORT', "8002"))
 
 CACHEDIR  = os.path.join( MYDIR, "cache" )
 IP2LCACHE = os.path.join( MYDIR, "cache/ip2l" )
@@ -260,6 +262,6 @@ def wttr(location = None):
         logging.error("Exception has occured", exc_info=1)
         return str(e).rstrip()+"\n"
 
-server = WSGIServer(("", 8002), app)
+server = WSGIServer((LISTEN_HOST, LISTEN_PORT), app)
 server.serve_forever()
 


### PR DESCRIPTION
With this change you can set via environment variables the listen host and port. Very useful if you have busy the default port or you can set to listen on localport only (set as default now).
