### PR TITLE
Add Russian alias for Kharkiv

### DIFF
--- a/share/aliases
+++ b/share/aliases
@@ -4,4 +4,5 @@ Moskau      : Moscow
 Kyiv        : Kiev
 Kiew        : Kiev
 Kijev       : Kiev
+Kharkov     : Kharkiv
 spb         : Saint Petersburg


### PR DESCRIPTION
Add "Kharkov" alias for Ukrainian city of Kharkiv. Otherwise wttr.in displays weather for small Armenian village of Kharkov.