### PR TITLE
Define monospace fonts more explicitly

### DIFF
--- a/share/static/style.css
+++ b/share/static/style.css
@@ -2,3 +2,7 @@ body {
     background: black;
     color: #bbbbbb;
 }
+
+pre {
+    font-family: DejaVu Sans Mono, Menlo, monospace;
+}


### PR DESCRIPTION
Define monospace fonts more explicitly to avoid rendering issues on various operating systems. Long story short, not all monospace fonts are created equal and their handling of wide unicode characters differs. I tried a lot of fonts and DejaVu Sans Mono handles well for Linux (and derivatives such as ChromeOS) and Menlo handles well for OS X. I don't have an opportunity to find a good one for Windows so I'll leave that as an exercise for someone who uses Windows.

The fallback of monospace is still there so this should only improve the situation for those having issues. See: #22  