### PR TITLE
Support DNS LOC record for @<domain> queries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ geoip2
 geopy
 requests
 gevent
+dnspython


### PR DESCRIPTION
Query LOC record first; use IP address as fallback.

Example:
/@traunstein.deebas.com should resolve to 47.8732072,13.8397961 (a mountain in Austria)