### PR TITLE
Add aliase Braga, Portugal

### DIFF
--- a/share/aliases
+++ b/share/aliases
@@ -45,3 +45,4 @@ Bjalistoko  : Białystok
 Chicago     : Chicago,IL
 Paris       : Paris,France
 Giessen     : Giessen, Germany
+Braga       : Braga, Portugal


### PR DESCRIPTION
There was an issue that when someone try to use http://wttr.in/Braga it shows the time for Braganca Paulista, Brazil instead of Braga, Portugal 