### PR TITLE
Add OpenBSD ftp(1) to the PLAIN_TEXT list

### DIFF
--- a/lib/globals.py
+++ b/lib/globals.py
@@ -59,7 +59,8 @@ PLAIN_TEXT_AGENTS = [
     "httpie",
     "lwp-request",
     "wget",
-    "python-requests"
+    "python-requests",
+    "OpenBSD ftp"
 ]
 
 PLAIN_TEXT_PAGES = [':help', ':bash.function', ':translation']


### PR DESCRIPTION
The [ftp](http://man.openbsd.org/ftp) command is the default tool to fetch files over HTTP on OpenBSD. It could be nice to add it to the PLAIN_TEXT_AGENTS list so installing curl or wget is not necessary.

Its user-agent is, as described in the man page, “OpenBSD ftp”.