### PR TITLE
Silence curl for multi URL requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Nuremberg: 🌦 +11⁰C
 Or to process all this queries at once:
 
 ```
-$ curl 'wttr.in/{Nuremberg,Hamburg,Berlin}?format=3'
+$ curl -s 'wttr.in/{Nuremberg,Hamburg,Berlin}?format=3'
 Nuremberg: 🌦 +11⁰C
 Hamburg: 🌦 +8⁰C
 Berlin: 🌦 +8⁰C


### PR DESCRIPTION
Curl emits messages like below if used without the `-s` flag.
```
[1/3]: wttr.in/Nuremberg?format=3 --> <stdout>
--_curl_--wttr.in/Nuremberg?format=3
Nuremberg: ☀️ +14°C

[2/3]: wttr.in/Hamburg?format=3 --> <stdout>
--_curl_--wttr.in/Hamburg?format=3
Hamburg: ☀️ +15°C

[3/3]: wttr.in/Berlin?format=3 --> <stdout>
--_curl_--wttr.in/Berlin?format=3
Berlin: ☀️ +15°C
```