### PR TITLE
Should fix monospace char issues in Android

### DIFF
--- a/share/static/style.css
+++ b/share/static/style.css
@@ -12,7 +12,7 @@ font-size: 70%;
 
 /*font-family: Lucida Console,Lucida Sans Typewriter,monaco,Bitstream Vera Sans Mono,monospace; */
 /*Droid Sans Mono*/
-font-family: "DejaVu Sans Mono", Menlo, "Lucida Sans Typewriter", "Lucida Console", monaco, "Bitstream Vera Sans Mono", monospace;
+font-family: "Source Code Pro", "DejaVu Sans Mono", Menlo, "Lucida Sans Typewriter", "Lucida Console", monaco, "Bitstream Vera Sans Mono", monospace;
 /*font-family: bitstream_vera_sans_monoroman;*/
 font-size: 75%;
 }

--- a/share/templates/index.html
+++ b/share/templates/index.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<link rel="stylesheet" type="text/css" href="https://adobe-fonts.github.io/source-code-pro/source-code-pro.css">
 <link rel="stylesheet" type="text/css" href="/files/style.css" />
 </head>
 <body>


### PR DESCRIPTION
Some bar drawing gliphs are missing in Android. Adobe's Source Code Pro
has them all, so it's one option to fix it on all platforms.

If you wish you can also host the font locally.

https://stackoverflow.com/questions/51892280/how-do-i-fix-monospace-spaces-not-being-correct-width-in-android-chrome-firefox/52712376