### PR TITLE
Fixed error in bash function

### DIFF
--- a/share/bash-function.txt
+++ b/share/bash-function.txt
@@ -2,6 +2,6 @@ wttr()
 {
     # change Paris to your default location
     local request="wttr.in/${1-Paris}"
-    [ "$COLUMNS" -lt 125 ] && request+='?n'
+    [ "$(tput cols)" -lt 125 ] && request+='?n'
     curl -H "Accept-Language: ${LANG%_*}" --compressed "$request"
 }


### PR DESCRIPTION
Replaced `"$COLUMNS"` with `"$(tput cols)"` in line 5, because shell variables are not exported to child processes.