### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "echo Enter city to receive weather data from: ;read city; eval \"curl wttr.in/$city\";"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 *wttr.in — the right way to check the weather!*
 
+[![Run on Repl.it](https://repl.it/badge/github/chubin/wttr.in)](https://repl.it/github/chubin/wttr.in)
+
 wttr.in is a console-oriented weather forecast service that supports various information
 representation methods like terminal-oriented ANSI-sequences for console HTTP clients
 (curl, httpie, or wget), HTML for web browsers, or PNG for graphical viewers.


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@joshwood/wttrin).