### PR TITLE
Add extra=localObsTime to weather-data fetch query

### DIFF
--- a/bin/proxy.py
+++ b/bin/proxy.py
@@ -180,6 +180,7 @@ def proxy(path):
     query_string = request.query_string
     query_string = query_string.replace('sr-lat', 'sr')
     query_string = query_string.replace('lang=None', 'lang=en')
+    query_string += "&extra=localObsTime"
     content, headers = _load_content_and_headers(path, query_string)
 
     if content is None:


### PR DESCRIPTION
The `extra` parameter can accept multiple values. The one we're interested in
is `localObsTime`. What it does is:

Adds the current weather observation time in UTC as well as local time of the location requested.

source: https://www.worldweatheronline.com/developer/api/docs/local-city-town-weather-api.aspx