### PR TITLE
Add `includelocation=yes` to weather-data query string

### DIFF
--- a/bin/proxy.py
+++ b/bin/proxy.py
@@ -181,6 +181,7 @@ def proxy(path):
     query_string = query_string.replace('sr-lat', 'sr')
     query_string = query_string.replace('lang=None', 'lang=en')
     query_string += "&extra=localObsTime"
+    query_string += "&includelocation=yes"
     content, headers = _load_content_and_headers(path, query_string)
 
     if content is None:


### PR DESCRIPTION
The WWO request parameters can accept `includelocation=yes` to include
the nearest weather point in the JSON results.

This is useful to display the name of the location.

source: https://www.worldweatheronline.com/developer/api/docs/local-city-town-weather-api.aspx