### PR TITLE
prometheus: Proper help format

### DIFF
--- a/lib/view/prometheus.py
+++ b/lib/view/prometheus.py
@@ -31,16 +31,18 @@ def _render_current(data):
     current_condition = data["current_condition"][0]
     for field in EXPORTED_FIELDS:
         try:
-            output.append("# %s\n%s{forecast=\"0h\"} %s" %
-                          (EXPORTED_FIELDS[field][0],
+            output.append("# HELP %s %s\n%s{forecast=\"0h\"} %s" %
+                          (EXPORTED_FIELDS[field][1],
+                           EXPORTED_FIELDS[field][0],
                            EXPORTED_FIELDS[field][1],
                            current_condition[field]))
         except IndexError:
             pass
     for field in EXPORTED_FIELDS_DESC:
         try:
-            output.append("# %s\n%s{forecast=\"0h\", description=\"%s\"} 1" %
-                          (EXPORTED_FIELDS_DESC[field][0],
+            output.append("# HELP %s %s\n%s{forecast=\"0h\", description=\"%s\"} 1" %
+                          (EXPORTED_FIELDS_DESC[field][1],
+                           EXPORTED_FIELDS_DESC[field][0],
                            EXPORTED_FIELDS_DESC[field][1],
                            current_condition[field]))
         except IndexError:


### PR DESCRIPTION
One more fix, sorry I missed that. Help text needs to start with expected format for the help text is: `# HELP metric_name Description`