### PR TITLE
Fix current time output of pngs

### DIFF
--- a/lib/wttr_srv.py
+++ b/lib/wttr_srv.py
@@ -221,7 +221,7 @@ def _response(parsed_query, query, fast_mode=False):
         #
         #    output = fmt.png.render_ansi(
         #        output, options=parsed_query)
-        result = TASKS.spawn(fmt.png.render_ansi, output, options=parsed_query)
+        result = TASKS.spawn(fmt.png.render_ansi, cache._update_answer(output), options=parsed_query)
         output = result.get()
     else:
         if query.get('days', '3') != '0' \


### PR DESCRIPTION
Pictures of a request that display a certain time show "%{{NOW(*timezone*)}}.
compare [munich](http://v2.wttr.in/munich) and [munich.png](http://v2.wttr.in/munich.png)

This is because of a conversion to an image before the response is passed to the cache where the expression %{{NOW is searched for and replaced for an updated time without re-querying wego. 

This update should fix this issue, but not any other pre-cache errors that may be present that I am unaware of.