### PR TITLE
"frankfurt" should default to the big Frankfurt

### DIFF
--- a/share/aliases
+++ b/share/aliases
@@ -29,7 +29,7 @@ nürnberg    : Nuremberg
 norway      : Oslo
 ville de bruxelles - stad brussel: Brussels
 frankfurt am main:Frankfurt, Hessen
-frankfurt   :Frankfurt, Brandenburg
+frankfurt   :Frankfurt, Hessen
 frankfurt oder : Frankfurt, Brandenburg
 frankfurt (oder): Frankfurt, Brandenburg
 tel-aviv    : Tel Aviv


### PR DESCRIPTION
Frankfurt [am Main], Hessen is the big one. It's what people mean when they refer to Frankfurt, Germany.