### PR TITLE
make Docker image smaller and more reusable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,87 @@
-FROM ubuntu:18.04
-
-RUN apt-get update && \
-    apt-get install -y curl \
-                       git \
-                       python \
-                       python-pip \
-                       python-dev \
-                       autoconf \
-                       libtool \
-                       gawk
-RUN curl -O https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz
-RUN tar xvf go1.10.3.linux-amd64.tar.gz
+# Build stage
+FROM golang:1-alpine as builder
 
 WORKDIR /app
 
-COPY ./bin /app/bin
-COPY ./lib /app/lib
-COPY ./share /app/share
-COPY ./requirements.txt /app
-COPY ./src/we-lang/we-lang.go /app
+COPY ./share/we-lang/we-lang.go /app
 
-# There are several files that must be fetched/created manually
-# before building the image
-COPY ./.wegorc /root
-COPY ./.ip2location.key /root
-COPY ./airports.dat /app
-COPY ./GeoLite2-City.mmdb /app
+RUN apk add --no-cache git
 
-RUN export PATH=$PATH:/go/bin && \ 
+
+RUN true && \ 
     go get -u github.com/mattn/go-colorable && \
     go get -u github.com/klauspost/lctime && \
     go get -u github.com/mattn/go-runewidth && \
-    export GOBIN="/root/go/bin" && \
-    go install /app/we-lang.go
+    CGO_ENABLED=0 go build /app/we-lang.go
+# Results in /app/we-lang
 
-RUN pip install -r requirements.txt
 
-RUN mkdir /app/cache
-RUN mkdir -p /var/log/supervisor && \
-    mkdir -p /etc/supervisor/conf.d
-RUN chmod -R o+rw /var/log/supervisor && \
-    chmod -R o+rw /var/run
+# FROM ubuntu:18.04
+# RUN apt-get update && \
+#     apt-get install -y curl \
+#                        git \
+#                        python \
+#                        python-pip \
+#                        python-dev \
+#                        autoconf \
+#                        libtool \
+#                        gawk
+FROM alpine:3
+
+WORKDIR /app
+
+COPY ./requirements.txt /app
+
+ENV LLVM_CONFIG=/usr/bin/llvm9-config
+
+RUN apk add --no-cache \
+    python3 \
+    py3-pip \
+    py3-scipy \
+    py3-wheel \
+    py3-gevent \
+    zlib \
+    jpeg \
+    gcc \
+    g++ \
+    llvm9 \
+    make \
+    autoconf \
+    automake \
+    libtool \
+    supervisor \
+    zlib-dev \
+    jpeg-dev \
+    llvm9-dev \
+    py3-numpy-dev \
+    python3-dev && \
+    mkdir -p /app/cache && \
+    mkdir -p /var/log/supervisor && \
+    mkdir -p /etc/supervisor/conf.d && \
+    chmod -R o+rw /var/log/supervisor && \
+    chmod -R o+rw /var/run && \
+    pip install -r requirements.txt && \
+    apk del --no-cache -r gcc g++ make autoconf automake libtool zlib-dev jpeg-dev llvm9-dev
+
+COPY --from=builder /app/we-lang /app/bin/we-lang
+COPY ./bin /app/bin
+COPY ./lib /app/lib
+COPY ./share /app/share
+
+# These files should be mounted by the user at runtime:
+# /root/.wegorc
+# /root/.ip2location.key (optional)
+# /app/airports.dat
+# /app/GeoLite2-City.mmdb
+
 COPY share/docker/supervisord.conf /etc/supervisor/supervisord.conf
 
 ENV WTTR_MYDIR="/app"
 ENV WTTR_GEOLITE="/app/GeoLite2-City.mmdb"
-ENV WTTR_WEGO="/root/go/bin/we-lang"
+ENV WTTR_WEGO="/app/bin/we-lang"
 ENV WTTR_LISTEN_HOST="0.0.0.0"
 ENV WTTR_LISTEN_PORT="8002"
 
 EXPOSE 8002
 
-CMD ["/usr/local/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/share/docker/supervisord.conf
+++ b/share/docker/supervisord.conf
@@ -4,17 +4,17 @@ logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 [program:srv]
-command=python /app/bin/srv.py
+command=python3 /app/bin/srv.py
 stderr_logfile=/var/log/supervisor/srv-stderr.log
 stdout_logfile=/var/log/supervisor/srv-stdout.log
 
 [program:proxy]
-command=python /app/bin/proxy.py
+command=python3 /app/bin/proxy.py
 stderr_logfile=/var/log/supervisor/proxy-stderr.log
 stdout_logfile=/var/log/supervisor/proxy-stdout.log
 
 [program:geoproxy]
-command=python /app/bin/geo-proxy.py
+command=python3 /app/bin/geo-proxy.py
 stderr_logfile=/var/log/supervisor/geoproxy-stderr.log
 stdout_logfile=/var/log/supervisor/geoproxy-stdout.log
 


### PR DESCRIPTION
This PR creates a multi-stage docker build, allowing for smaller docker images. The runtime image is now based on alpine and doesn't carry all the golang infrastructure. I also moved the per-user specific COPY commands, allowing a user to mount these at runtime, which will allow publishing images directly to dockerhub.