### PR TITLE
Observe region data from all Geo-IP sources

### DIFF
--- a/lib/location.py
+++ b/lib/location.py
@@ -293,8 +293,8 @@ def location_processing(location, ip_addr):
                 socket.gethostbyname(
                     location.lstrip('~ ')[1:]))
             location = '~' + location
-            if country:
-                location += ", %s" % country
+            if region and country:
+                location += ", %s, %s" % (region, country)
             hide_full_address = not force_show_full_address
         except:
             location, region, country = NOT_FOUND_LOCATION, None, None
@@ -318,7 +318,7 @@ def location_processing(location, ip_addr):
         # here too
         if location:
             location = '~' + location
-            if country:
+            if region and country:
                 location += ", %s, %s" % (region, country)
             hide_full_address = not force_show_full_address
 

--- a/lib/location.py
+++ b/lib/location.py
@@ -67,7 +67,7 @@ def location_normalize(location):
 def geolocator(location):
     """
     Return a GPS pair for specified `location` or None
-    if nothing can't be found
+    if nothing can be found
     """
 
     try:
@@ -262,9 +262,9 @@ def get_hemisphere(location):
     Return hemisphere of the location (True = North, False = South).
     Assume North and return True if location can't be found.
     """
-    location_string = location[0]
-    if location[1] is not None:
-        location_string += ",%s" % location[1]
+    if all(location):
+        location_string = ", ".join(location)
+
     geolocation = geolocator(location_string)
     if geolocation is None:
         return True

--- a/lib/location.py
+++ b/lib/location.py
@@ -158,11 +158,13 @@ def geoip(ip_addr):
     try:
         response = GEOIP_READER.city(ip_addr)
         country = response.country.name
+        region = response.subdivisions.name
         city = response.city.name
     except geoip2.errors.AddressNotFoundError:
         country = None
+        region = None
         city = None
-    return city, country
+    return city, region, country
 
 def workaround(city, country):
     # workaround for the strange bug with the country name

--- a/lib/location.py
+++ b/lib/location.py
@@ -143,20 +143,19 @@ def ip2location(ip_addr):
 
 
 def ipinfo(ip_addr):
-    location = ipcache(ip_addr)
-    if location:
-        return location
-    if IPINFO_TOKEN:
-        r = requests.get('https://ipinfo.io/%s/json?token=%s' %
-                         (ip_addr, IPINFO_TOKEN))
-        if r.status_code == 200:
-            r_json = r.json()
-            location = r_json["city"], r_json["region"], r_json["country"]
-        else:
-            location = None, None, None
-    if location:
-        ipcachewrite(ip_addr, location)
-    return location
+    if not IPINFO_TOKEN:
+        return None, None, None
+    try:
+        r = requests.get(
+            'https://ipinfo.io/%s/json?token=%s'
+            % (ip_addr, IPINFO_TOKEN))
+        r.raise_for_status()
+        r_json = r.json()
+        city, region, country = r_json["city"], r_json["region"], r_json["country"]
+    except (requests.exceptions.RequestException, ValueError):
+        # latter is thrown by failure to parse json in reponse
+        return None, None, None
+    return city, region, country
 
 
 def geoip(ip_addr):

--- a/lib/location.py
+++ b/lib/location.py
@@ -116,12 +116,21 @@ def _ipcachewrite(ip_addr, location):
     """ Write a retrieved ip+location into cache
         Can stress some filesystems after long term use, see
         https://stackoverflow.com/questions/466521/how-many-files-can-i-put-in-a-directory
+
+        Expects a location of the form:
+            `(city, region, country, country_code, <lat>, <long>)`
+        Writes a cache entry of the form:
+            `country_code;country;region;city;<lat>;<long>`
+
+        The latitude and longitude are optional elements.
     """
     cachefile = os.path.join(IP2LCACHE, ip_addr)
     if not os.path.exists(IP2LCACHE):
         os.makedirs(IP2LCACHE)
     with open(cachefile, 'w') as file:
-        file.write(location[3] + ';' + location[2] + ';' + location[1] + ';' + location[0] + ';' + location[4] + ';' + location[5])
+        file.write(location[3] + ';' + location[2] + ';' + location[1] + ';' + location[0])
+        if len(location) > 4:
+            file.write(';' + location[4] + ';' + location[5])
         # like ip2location format
 
 

--- a/lib/location.py
+++ b/lib/location.py
@@ -102,12 +102,13 @@ def ipcachewrite(ip_addr, location):
         os.makedirs(IP2LCACHE)
 
     with open(cachefile, 'w') as file:
-        file.write(location[0] + ';' + location[1] + ';' + location[2])
-        # like ip2location format, but reversed
+        file.write(location[3] + ';' + location[2] + ';' + location[1] + ';' + location[0] + ';' + location[4] + ';' + location[5])
+        # like ip2location format
 
 def ipcache(ip_addr):
     """ Retrieve a location from cache by ip addr
         Returns a triple of (CITY, REGION, COUNTRY) or None
+        TODO: When cache becomes more robust, transition to using latlong
     """
     cachefile = os.path.join(IP2LCACHE, ip_addr)
     if not os.path.exists(IP2LCACHE):
@@ -115,10 +116,11 @@ def ipcache(ip_addr):
 
     if os.path.exists(cachefile):
         try:
-            city, region, country = open(cachefile, 'r').read().split(';')
+            _, country, region, city, *_ = open(cachefile, 'r').read().split(';')
             return city, region, country
         except ValueError:
-            # cache entry is malformed: should be city;region;country
+            # cache entry is malformed: should be
+            # [ccode];country;region;city;[lat];[long];...
             return None
     return None
 

--- a/lib/location.py
+++ b/lib/location.py
@@ -149,7 +149,10 @@ def ipinfo(ip_addr):
         r = requests.get('https://ipinfo.io/%s/json?token=%s' %
                          (ip_addr, IPINFO_TOKEN))
         if r.status_code == 200:
-            location = r.json()["city"], r.json()["country"]
+            r_json = r.json()
+            location = r_json["city"], r_json["region"], r_json["country"]
+        else:
+            location = None, None, None
     if location:
         ipcachewrite(ip_addr, location)
     return location

--- a/lib/location.py
+++ b/lib/location.py
@@ -133,9 +133,10 @@ def ip2location(ip_addr):
 
     if location and ';' in location:
         ipcachewrite(ip_addr, location)
-        location = location.split(';')[3], location.split(';')[1]
+        _, country, region, city = location.split(';')
+        location = city, region, country
     else:
-        location = location, None
+        location = location, None, None
 
     return location
 

--- a/lib/location.py
+++ b/lib/location.py
@@ -291,7 +291,7 @@ def location_processing(location, ip_addr):
 
     if location and location.lstrip('~ ').startswith('@'):
         try:
-            location, country = get_location(
+            location, region, country = get_location(
                 socket.gethostbyname(
                     location.lstrip('~ ')[1:]))
             location = '~' + location
@@ -299,7 +299,7 @@ def location_processing(location, ip_addr):
                 location += ", %s" % country
             hide_full_address = not force_show_full_address
         except:
-            location, country = NOT_FOUND_LOCATION, None
+            location, region, country = NOT_FOUND_LOCATION, None, None
 
     query_source_location = get_location(ip_addr)
 
@@ -314,7 +314,8 @@ def location_processing(location, ip_addr):
         location = ip_addr
 
     if is_ip(location):
-        location, country = get_location(location)
+        location, region, country = get_location(location)
+        # location is just city here
 
         # here too
         if location:

--- a/lib/location.py
+++ b/lib/location.py
@@ -90,10 +90,15 @@ def geolocator(location):
 
 
 def ipcachewrite(ip_addr, location):
-    cached = os.path.join(IP2LCACHE, ip_addr)
+    """ Write a retrieved ip+location into cache
+        Can stress some filesystems after long term use, see
+        https://stackoverflow.com/questions/466521/how-many-files-can-i-put-in-a-directory
+    """
+    cachefile = os.path.join(IP2LCACHE, ip_addr)
     if not os.path.exists(IP2LCACHE):
         os.makedirs(IP2LCACHE)
-    with open(cached, 'w') as file:
+
+    with open(cachefile, 'w') as file:
         file.write(location[0] + ';' + location[1] + ';' + location[2])
         # like ip2location format, but reversed
 

--- a/lib/location.py
+++ b/lib/location.py
@@ -22,6 +22,8 @@ from globals import GEOLITE, GEOLOCATOR_SERVICE, IP2LCACHE, IP2LOCATION_KEY, NOT
 
 GEOIP_READER = geoip2.database.Reader(GEOLITE)
 
+COUNTRY_MAP = {"Russian Federation": "Russia"}
+
 def ascii_only(string):
     "Check if `string` contains only ASCII symbols"
 
@@ -165,15 +167,11 @@ def geoip(ip_addr):
         return None, None, None
     return city, region, country
 
-def workaround(city, region, country):
-    # workaround for the strange bug with the country name
+def workaround(country):
+    # workaround for strange bug with the country name
     # maybe some other countries has this problem too
-    #
-    # Having these in a separate function will help if this gets to
-    # be a problem
-    if country == 'Russian Federation':
-        country = 'Russia'
-    return city, region, country
+    country = COUNTRY_MAP.get(country) or country
+    return country
 
 def get_location(ip_addr):
     """

--- a/lib/location.py
+++ b/lib/location.py
@@ -144,18 +144,22 @@ def ip2location(ip_addr):
 
 def ipinfo(ip_addr):
     if not IPINFO_TOKEN:
-        return None, None, None
+        return None
     try:
         r = requests.get(
             'https://ipinfo.io/%s/json?token=%s'
             % (ip_addr, IPINFO_TOKEN))
         r.raise_for_status()
         r_json = r.json()
-        city, region, country = r_json["city"], r_json["region"], r_json["country"]
+        # can't do two unpackings on one line
+        city, region, country, ccode  = r_json["city"], r_json["region"], '', r_json["country"],
+        lat, long = r_json["loc"].split(',')
+        # NOTE: ipinfo only provides ISO codes for countries
+        country = pycountry.countries.get(alpha_2=ccode).name
     except (requests.exceptions.RequestException, ValueError):
         # latter is thrown by failure to parse json in reponse
-        return None, None, None
-    return city, region, country
+        return None
+    return city, region, country, ccode, lat, long
 
 
 def geoip(ip_addr):

--- a/lib/location.py
+++ b/lib/location.py
@@ -103,22 +103,22 @@ def ipcachewrite(ip_addr, location):
         # like ip2location format, but reversed
 
 def ipcache(ip_addr):
-    cached = os.path.join(IP2LCACHE, ip_addr)
+    """ Retrieve a location from cache by ip addr
+        Returns a triple of (CITY, REGION, COUNTRY) or None
+    """
+    cachefile = os.path.join(IP2LCACHE, ip_addr)
     if not os.path.exists(IP2LCACHE):
         os.makedirs(IP2LCACHE)
 
-    location = None
+    if os.path.exists(cachefile):
+        try:
+            city, region, country = open(cachefile, 'r').read().split(';')
+            return city, region, country
+        except ValueError:
+            # cache entry is malformed: should be city;region;country
+            return None
+    return None
 
-    if os.path.exists(cached):
-        location = open(cached, 'r').read().split(';')
-        if len(location) > 3:
-            return location[3], location[1]
-        elif len(location) > 1:
-            return location[0], location[1]
-        else:
-            return location[0], None
-
-    return None, None
 
 def ip2location(ip_addr):
     """Convert IP address `ip_addr` to a location name"""

--- a/lib/location.py
+++ b/lib/location.py
@@ -160,18 +160,12 @@ def ipinfo(ip_addr):
 
 
 def geoip(ip_addr):
-    location = ipcache(ip_addr)
-    if location:
-        return location
-
     try:
         response = GEOIP_READER.city(ip_addr)
-        location = response.city.name, response.subdivisions.name, response.country.name
+        city, region, country = response.city.name, response.subdivisions.name, response.country.name
     except geoip2.errors.AddressNotFoundError:
-        location = None, None, None
-    if location:
-        ipcachewrite(ip_addr, location)
-    return location
+        return None, None, None
+    return city, region, country
 
 def workaround(city, region, country):
     # workaround for the strange bug with the country name

--- a/lib/location.py
+++ b/lib/location.py
@@ -165,14 +165,12 @@ def geoip(ip_addr):
 
     try:
         response = GEOIP_READER.city(ip_addr)
-        country = response.country.name
-        region = response.subdivisions.name
-        city = response.city.name
+        location = response.city.name, response.subdivisions.name, response.country.name
     except geoip2.errors.AddressNotFoundError:
-        country = None
+        location = None, None, None
         region = None
         city = None
-    return city, region, country
+    return location
 
 def workaround(city, region, country):
     # workaround for the strange bug with the country name

--- a/lib/location.py
+++ b/lib/location.py
@@ -128,19 +128,18 @@ def ip2location(ip_addr):
     # if IP2LOCATION_KEY is not set, do not query,
     # because the query wont be processed anyway
     if not IP2LOCATION_KEY:
-        return None, None, None
+        return None
     try:
         r = requests.get(
-            'http://api.ip2location.com/?ip=%s&key=%s&package=WS3'
+            'http://api.ip2location.com/?ip=%s&key=%s&package=WS5'
             % (ip_addr, IP2LOCATION_KEY))
         r.raise_for_status()
         location = r.text
         if location and ';' in location:
-            _, country, region, city = location.split(';')
-            location = city, region, country
+            ccode, country, region, city, lat, long, *_ = location.split(';')
     except requests.exceptions.RequestException:
-        return None, None, None
-    return city, region, country
+        return None
+    return city, region, country, ccode, lat, long
 
 
 def ipinfo(ip_addr):

--- a/lib/location.py
+++ b/lib/location.py
@@ -1,11 +1,35 @@
 """
 All location related functions and converters.
 
-The main entry point is `location_processing`
-which gets `location` and `source_ip_address`
-and basing on this information generates
-precise location description.
+The main entry point is `location_processing` which gets `location` and
+`source_ip_address` and basing on this information generates precise location
+description.
 
+     [query]      -->   [location]      -->  [(lat,long)] -->
+                            ^
+                            |
+     [ip-address] --> _get_location()
+
+To resolve IP address into location, the module uses function `_get_location()`,
+which subsequenlty utilizes one of the three methods:
+
+* `_geoip2()` (local sqlite database);
+* `_ip2location()` (an external paid service);
+* `_ipinfo()` (an external free service).
+
+IP-address resolution data is saved in cache (_ipcachewrite, _ipcache).
+Cache entry format:
+
+    COUNTRY_CODE;COUNTRY;REGION;CITY[;REST]
+
+To resolve location name into a (lat,long) pair,
+an external service is used, which is wrapped
+with a function `_geolocator()`.
+
+Exports:
+
+    location_processing
+    is_location_blocked
 """
 from __future__ import print_function
 

--- a/lib/location.py
+++ b/lib/location.py
@@ -187,6 +187,10 @@ def get_location(ip_addr):
     """
     Return location triple (CITY, REGION, COUNTRY) for `ip_addr`
     """
+    location = ipcache(ip_addr)
+    if location:
+        return location
+
     for method in IPLOCATION_ORDER:
         if method == 'geoip':
             city, region, country = geoip(ip_addr)
@@ -195,10 +199,13 @@ def get_location(ip_addr):
         elif method == 'ipinfo':
             city, region, country = ipinfo(ip_addr)
         else:
-            print("ERROR: invalid iplocation method speficied: %s" % method)
-        if city is not None:
-            city, region, country = workaround(city, region, country)
-            return city, region, country
+            print("ERROR: invalid iplocation method specified: %s" % method)
+
+    if all((city, region, country)):
+        ipcachewrite(ip_addr, (city, region, country))
+        # cache write used to happen before workaround, preserve that
+        city, region, country = workaround(city, region, country)
+        return city, region, country
     #
     # temporary disabled it because of geoip services capcacity
     #

--- a/lib/location.py
+++ b/lib/location.py
@@ -94,7 +94,8 @@ def ipcachewrite(ip_addr, location):
     if not os.path.exists(IP2LCACHE):
         os.makedirs(IP2LCACHE)
     with open(cached, 'w') as file:
-        file.write(location[0] + ';' + location[1])
+        file.write(location[0] + ';' + location[1] + ';' + location[2])
+        # like ip2location format, but reversed
 
 def ipcache(ip_addr):
     cached = os.path.join(IP2LCACHE, ip_addr)

--- a/lib/location.py
+++ b/lib/location.py
@@ -168,8 +168,8 @@ def geoip(ip_addr):
         location = response.city.name, response.subdivisions.name, response.country.name
     except geoip2.errors.AddressNotFoundError:
         location = None, None, None
-        region = None
-        city = None
+    if location:
+        ipcachewrite(ip_addr, location)
     return location
 
 def workaround(city, region, country):

--- a/lib/location.py
+++ b/lib/location.py
@@ -15,6 +15,7 @@ import json
 import socket
 import requests
 import geoip2.database
+import pycountry
 
 from globals import GEOLITE, GEOLOCATOR_SERVICE, IP2LCACHE, IP2LOCATION_KEY, NOT_FOUND_LOCATION, \
                     ALIASES, BLACKLIST, IATA_CODES_FILE, IPLOCATION_ORDER, IPINFO_TOKEN

--- a/lib/location.py
+++ b/lib/location.py
@@ -185,7 +185,7 @@ def workaround(city, region, country):
 
 def get_location(ip_addr):
     """
-    Return location pair (CITY, COUNTRY) for `ip_addr`
+    Return location triple (CITY, REGION, COUNTRY) for `ip_addr`
     """
     for method in IPLOCATION_ORDER:
         if method == 'geoip':

--- a/lib/location.py
+++ b/lib/location.py
@@ -165,10 +165,11 @@ def ipinfo(ip_addr):
 def geoip(ip_addr):
     try:
         response = GEOIP_READER.city(ip_addr)
-        city, region, country = response.city.name, response.subdivisions.name, response.country.name
+        city, region, country, ccode, lat, long = response.city.name, response.subdivisions.name, response.country.name, response.country.iso_code, response.location.latitude, response.location.longitude
     except geoip2.errors.AddressNotFoundError:
-        return None, None, None
-    return city, region, country
+        return None
+    return city, region, country, ccode, lat, long
+
 
 def workaround(country):
     # workaround for strange bug with the country name

--- a/lib/location.py
+++ b/lib/location.py
@@ -155,6 +155,10 @@ def ipinfo(ip_addr):
 
 
 def geoip(ip_addr):
+    location = ipcache(ip_addr)
+    if location:
+        return location
+
     try:
         response = GEOIP_READER.city(ip_addr)
         country = response.country.name

--- a/lib/location.py
+++ b/lib/location.py
@@ -409,3 +409,21 @@ def location_processing(location, ip_addr):
             country, \
             query_source_location, \
             hemisphere
+
+
+def _main_():
+    """ Validate cache entries. Print names of invalid cache entries
+        and move it to the "broken-entries" directory."""
+
+    import glob
+    import shutil
+
+    for filename in glob.glob(os.path.join(IP2LCACHE, "*")):
+        ip_address = os.path.basename(filename)
+        if not _ipcache(ip_address):
+            print(ip_address)
+            shutil.move(filename, os.path.join("/wttr.in/cache/ip2l-broken", ip_address))
+
+
+if __name__ == "__main__":
+    _main_()

--- a/lib/location.py
+++ b/lib/location.py
@@ -196,6 +196,8 @@ def get_location(ip_addr):
             location = ipinfo(ip_addr)
         else:
             print("ERROR: invalid iplocation method specified: %s" % method)
+        if location is not None:
+            break
 
     if location is not None and all(location):
         ipcachewrite(ip_addr, location)

--- a/lib/location.py
+++ b/lib/location.py
@@ -185,22 +185,25 @@ def get_location(ip_addr):
     if location:
         return location
 
+    # location from iplocators have the following order:
+    # (CITY, REGION, COUNTRY, CCODE, LAT, LONG)
     for method in IPLOCATION_ORDER:
         if method == 'geoip':
-            city, region, country = geoip(ip_addr)
+            location = geoip(ip_addr)
         elif method == 'ip2location':
-            city, region, country = ip2location(ip_addr)
+            location = ip2location(ip_addr)
         elif method == 'ipinfo':
-            city, region, country = ipinfo(ip_addr)
+            location = ipinfo(ip_addr)
         else:
             print("ERROR: invalid iplocation method specified: %s" % method)
 
-    if all((city, region, country)):
-        ipcachewrite(ip_addr, (city, region, country))
+    if location is not None and all(location):
+        ipcachewrite(ip_addr, location)
         # cache write used to happen before workaround, preserve that
-        city, region, country = workaround(city, region, country)
-        return city, region, country
-    #
+        location[2] = workaround(location[2])
+        return location[:3]  # city, region, country
+        # ccode is cached but not needed for location
+
     # temporary disabled it because of geoip services capcacity
     #
     #if city is None and response.location:

--- a/lib/location.py
+++ b/lib/location.py
@@ -174,7 +174,7 @@ def geoip(ip_addr):
         city = None
     return city, region, country
 
-def workaround(city, country):
+def workaround(city, region, country):
     # workaround for the strange bug with the country name
     # maybe some other countries has this problem too
     #
@@ -182,7 +182,7 @@ def workaround(city, country):
     # be a problem
     if country == 'Russian Federation':
         country = 'Russia'
-    return city, country
+    return city, region, country
 
 def get_location(ip_addr):
     """

--- a/lib/location.py
+++ b/lib/location.py
@@ -153,15 +153,16 @@ def _ip2location(ip_addr):
         return None
     try:
         r = requests.get(
-            'http://api.ip2location.com/?ip=%s&key=%s&package=WS5'
+            'http://api.ip2location.com/?ip=%s&key=%s&package=WS3'  # WS5 provides latlong
             % (ip_addr, IP2LOCATION_KEY))
         r.raise_for_status()
         location = r.text
         if location and ';' in location:
-            ccode, country, region, city, lat, long, *_ = location.split(';')
+            # ccode, country, region, city, lat, long, *_ = location.split(';')
+            ccode, country, region, city, *_ = location.split(';')
     except requests.exceptions.RequestException:
         return None
-    return city, region, country, ccode, lat, long
+    return city, region, country, ccode  # , lat, long
 
 
 def _ipinfo(ip_addr):

--- a/lib/location.py
+++ b/lib/location.py
@@ -321,7 +321,7 @@ def location_processing(location, ip_addr):
         if location:
             location = '~' + location
             if country:
-                location += ", %s" % country
+                location += ", %s, %s" % (region, country)
             hide_full_address = not force_show_full_address
 
     if location and not location.startswith('~'):

--- a/lib/location.py
+++ b/lib/location.py
@@ -188,16 +188,16 @@ def get_location(ip_addr):
     """
     for method in IPLOCATION_ORDER:
         if method == 'geoip':
-            city, country = geoip(ip_addr)
+            city, region, country = geoip(ip_addr)
         elif method == 'ip2location':
-            city, country = ip2location(ip_addr)
+            city, region, country = ip2location(ip_addr)
         elif method == 'ipinfo':
-            city, country = ipinfo(ip_addr)
+            city, region, country = ipinfo(ip_addr)
         else:
             print("ERROR: invalid iplocation method speficied: %s" % method)
         if city is not None:
-            city, country = workaround(city, country)
-            return city, country
+            city, region, country = workaround(city, region, country)
+            return city, region, country
     #
     # temporary disabled it because of geoip services capcacity
     #
@@ -210,7 +210,7 @@ def get_location(ip_addr):
     #        pass
 
     # No methods resulted in a location - return default
-    return NOT_FOUND_LOCATION, None
+    return NOT_FOUND_LOCATION, None, None
 
 
 def location_canonical_name(location):

--- a/lib/view/wttr.py
+++ b/lib/view/wttr.py
@@ -36,9 +36,28 @@ def get_wetter(parsed_query):
         (returncode != 0 \
             and ('Unable to find any matching weather'
                  ' location to the parsed_query submitted') in stderr):
-            stdout, stderr, returncode = _wego_wrapper(NOT_FOUND_LOCATION, parsed_query)
-            location_not_found = True
-            stdout += get_message('NOT_FOUND_MESSAGE', lang)
+        stdout, stderr, returncode = _wego_wrapper(DEFAULT_LOCATION, parsed_query)
+        location_not_found = True
+
+        not_found_header = """
+>>>    _  _    ___  _  _     
+>>>   | || |  / _ \| || |      
+>>>   | || |_| | | | || |_      
+>>>   |__   _| |_| |__   _|      
+>>>      |_|  \___/   |_|    
+>>>                       
+>>>   404 %s: %s
+>>>                 
+""" % (get_message("UNKNOWN_LOCATION", lang).upper(), parsed_query['override_location_name'])
+
+        not_found_header = "\n".join("\033[48;5;91m" + x + "   \033[0m"
+                                     for x in not_found_header.splitlines()[1:])
+
+        not_found_footer = get_message('NOT_FOUND_MESSAGE', lang)
+        not_found_footer = "\n".join("\033[48;5;91m " + x + " \033[0m"
+                                     for x in not_found_footer.splitlines() if x) + "\n"
+
+        stdout = not_found_header + "\n----\n" + stdout + not_found_footer
 
     if "\n" in stdout:
         first_line, stdout = _wego_postprocessing(location, parsed_query, stdout)
@@ -53,7 +72,10 @@ def get_wetter(parsed_query):
 def _wego_wrapper(location, parsed_query):
 
     lang = parsed_query['lang']
-    location_name = parsed_query['override_location_name']
+    if location == DEFAULT_LOCATION:
+        location_name = DEFAULT_LOCATION.capitalize()
+    else:
+        location_name = parsed_query['override_location_name']
 
     cmd = [WEGO, '--city=%s' % location]
 

--- a/lib/wttr_srv.py
+++ b/lib/wttr_srv.py
@@ -298,7 +298,7 @@ def parse_request(location, request, query, fast_mode=False):
         location, override_location_name, full_address, country, query_source_location, hemisphere = \
                 location_processing(parsed_query["location"], parsed_query["ip_addr"])
 
-        us_ip = query_source_location[1] == 'United States' \
+        us_ip = query_source_location[2] == 'United States' \
                 and 'slack' not in parsed_query['user_agent']
         query = parse_query.metric_or_imperial(query, lang, us_ip=us_ip)
 

--- a/lib/wttr_srv.py
+++ b/lib/wttr_srv.py
@@ -298,7 +298,8 @@ def parse_request(location, request, query, fast_mode=False):
         location, override_location_name, full_address, country, query_source_location, hemisphere = \
                 location_processing(parsed_query["location"], parsed_query["ip_addr"])
 
-        us_ip = query_source_location[2] == 'United States' \
+        us_ip = (query_source_location[2] == 'United States' or \
+                query_source_location[2] == 'Unites States of America') \
                 and 'slack' not in parsed_query['user_agent']
         query = parse_query.metric_or_imperial(query, lang, us_ip=us_ip)
 

--- a/lib/wttr_srv.py
+++ b/lib/wttr_srv.py
@@ -375,6 +375,10 @@ def wttr(location, request):
         if not response:
             parsed_query = parse_request(location, request, query)
             response = _response(parsed_query, query)
+
+            if parsed_query["location"] == NOT_FOUND_LOCATION:
+                http_code = 404
+
     # pylint: disable=broad-except
     except Exception as exception:
         logging.error("Exception has occured", exc_info=1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ supervisor
 numba
 emoji
 grapheme
+pycountry


### PR DESCRIPTION
These changes no longer invalidate the cache, but it caches differently from how it used to. Please observe that.

The cache used to be stored as one of the three following:
city;country
countrycode;country;region;city

The former was custom, retrieved from ipinfo, and the latter was stored directly from ip2location. The new format stores data from all three sources, and matches the existing City, Country formatting but with Region added between. 

With some other new changes, latitude and longitude are included in the cache as well. The final format is the following:

COUNTRY_CODE;COUNTRY;REGION;CITY;LATITUDE;LONGITUDE

These changes are as yet untested, which is why I've marked this as a draft. However, I am reasonably confident in these changes thus far; individual functions in location.py have been tested (those I can get keys for). I have yet to read further than wttr.py to find places where the user's location/requested location matter, so there may be other breaking changes I've yet to identify.

This pull request closes #492 