### PR TITLE
Add ‘foot’ to list of terminals with image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Terminal with inline images protocols support:
 | Jexer                 |   X11     |   yes         |   Sixel   |
 | GNOME Terminal        |   X11     |   [in-progress](https://gitlab.gnome.org/GNOME/vte/-/issues/253) |   Sixel   |
 | alacritty             |   X11     |   [in-progress](https://github.com/alacritty/alacritty/issues/910) |  Sixel   |
+| foot                  |  Wayland  |   yes         |   Sixel   |
 | DomTerm               |   Web     |   yes         |   Sixel   |
 | Yaft                  |   FB      |   yes         |   Sixel   |
 | iTerm2                |   Mac OS X|   yes         |   IIP     |


### PR DESCRIPTION
Foot (https://codeberg.org/dnkl/foot), a Linux Wayland terminal, has sixel support:
![foot-wttr-sixel](https://user-images.githubusercontent.com/14031526/98974582-5e34ed80-2515-11eb-953f-cb58574a400f.png)
