### PR TITLE
Removes use of -k option to curl in Kitty section in docs

### DIFF
--- a/doc/terminal-images.md
+++ b/doc/terminal-images.md
@@ -59,5 +59,5 @@ uxterm -ti vt340
 To view images in kitty:
 
 ```
-curl -ks v3.wttr.in/Tabasco.png | kitty icat --align=left
+curl -s v3.wttr.in/Tabasco.png | kitty icat --align=left
 ```


### PR DESCRIPTION
No https request is made. And even if, there should be no reason to allow insecure connections anyways.