### PR TITLE
Remove default from bash function

### DIFF
--- a/share/bash-function.txt
+++ b/share/bash-function.txt
@@ -1,7 +1,31 @@
-wttr()
-{
-    # change Paris to your default location
-    local request="wttr.in/${1-Paris}"
-    [ "$(tput cols)" -lt 125 ] && request+='?n'
-    curl -H "Accept-Language: ${LANG%_*}" --compressed "$request"
+#! /usr/bin/env bash
+# If you source this file, it will set WTTR_PARAMS as well as show weather.
+
+# WTTR_PARAMS is space-separated URL parameters, many of which are single characters that can be
+# lumped together. For example, "F q m" behaves the same as "Fqm".
+if [[ -z "$WTTR_PARAMS" ]]; then
+  # Form localized URL parameters for curl
+  if [[ -t 1 ]] && [[ "$(tput cols)" -lt 125 ]]; then
+      WTTR_PARAMS+='n'
+  fi 2> /dev/null
+  for _token in $( locale LC_MEASUREMENT ); do
+    case $_token in
+      1) WTTR_PARAMS+='m' ;;
+      2) WTTR_PARAMS+='u' ;;
+    esac
+  done 2> /dev/null
+  unset _token
+  export WTTR_PARAMS
+fi
+
+wttr() {
+  local location="${1// /+}"
+  command shift
+  local args=""
+  for p in $WTTR_PARAMS "$@"; do
+    args+=" --data-urlencode '$p' "
+  done
+  curl -fGsS -H "Accept-Language: ${LANG%_*}" $args --compressed "wttr.in/${location}"
 }
+
+wttr "$@"

--- a/share/bash-function.txt
+++ b/share/bash-function.txt
@@ -23,7 +23,7 @@ wttr() {
   command shift
   local args=""
   for p in $WTTR_PARAMS "$@"; do
-    args+=" --data-urlencode '$p' "
+    args+=" --data-urlencode $p "
   done
   curl -fGsS -H "Accept-Language: ${LANG%_*}" $args --compressed "wttr.in/${location}"
 }


### PR DESCRIPTION
Refinement of bash script:
- WTTR_PARAMS environment variable added on client side to hold preferences, such as format or units of measurement.
- WTTR_PARAMS is initially set based on locale metric/imperial preference.
- Arguments to script no longer choose Paris over wttr.in location detection

This makes command-line interface scripts a bit more general. Call `wttr` instead of a long `curl` call with %-escaping issues.

Thanks for the utility, and also for cheat.sh.