### PR TITLE
Fix Docker build for alpine:3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /app
 
 COPY ./requirements.txt /app
 
-ENV LLVM_CONFIG=/usr/bin/llvm-config
+ENV LLVM_CONFIG=/usr/bin/llvm10-config
 
 RUN apk add --no-cache --virtual .build \
     autoconf \


### PR DESCRIPTION
llvm-config is now deployed as /usr/bin/llvm10-config: https://pkgs.alpinelinux.org/contents?file=&path=&name=llvm10-dev&branch=v3.14&repo=main&arch=armhf