### PR TITLE
switch Dockerfile to llvm-11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apk add --no-cache --virtual .build \
     g++ \
     gcc \
     jpeg-dev \
-    llvm10-dev\
+    llvm11-dev\
     make \
     zlib-dev \
     && apk add --no-cache \
@@ -41,7 +41,7 @@ RUN apk add --no-cache --virtual .build \
     py3-gevent \
     zlib \
     jpeg \
-    llvm10 \
+    llvm11 \
     libtool \
     supervisor \
     py3-numpy-dev \


### PR DESCRIPTION
I tried to use @Artanicus changes proposed in opened PR #609, but it was unsuccessful: 

```
  ERROR: Command errored out with exit status 1:
   command: /usr/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-v7fd0qsh/llvmlite_2d5e74e65b57449b9ca2d13ab00f319e/setup.py'"'"'; __file__='"'"'/tmp/pip-install-v7fd0qsh/llvmlite_2d5e74e65b57449b9ca2d13ab00f319e/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-kdy8iwo_
       cwd: /tmp/pip-install-v7fd0qsh/llvmlite_2d5e74e65b57449b9ca2d13ab00f319e/
  Complete output (15 lines):
  running bdist_wheel
  /usr/bin/python3 /tmp/pip-install-v7fd0qsh/llvmlite_2d5e74e65b57449b9ca2d13ab00f319e/ffi/build.py
  LLVM version... 10.0.1
  
  Traceback (most recent call last):
    File "/tmp/pip-install-v7fd0qsh/llvmlite_2d5e74e65b57449b9ca2d13ab00f319e/ffi/build.py", line 220, in <module>
      main()
    File "/tmp/pip-install-v7fd0qsh/llvmlite_2d5e74e65b57449b9ca2d13ab00f319e/ffi/build.py", line 210, in main
      main_posix('linux', '.so')
    File "/tmp/pip-install-v7fd0qsh/llvmlite_2d5e74e65b57449b9ca2d13ab00f319e/ffi/build.py", line 172, in main_posix
      raise RuntimeError(msg)
  RuntimeError: Building llvmlite requires LLVM 11.x.x, got '10.0.1'. Be sure to set LLVM_CONFIG to the right executable path.
  Read the documentation at http://llvmlite.pydata.org/ for more information about building llvmlite.
  
  error: command '/usr/bin/python3' failed with exit code 1
  ----------------------------------------
  ERROR: Failed building wheel for llvmlite

```

TLDR:
```
RuntimeError: Building llvmlite requires LLVM 11.x.x, got '10.0.1'. Be sure to set LLVM_CONFIG to the right executable path.
```
That's why I updated llvm to version 11.

---

Btw, current Dockerfile crashes with:
```
  ERROR: Command errored out with exit status 1:
   command: /usr/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-bcduayqd/llvmlite_7ddfea482a25471e8f6e44e0fb54a699/setup.py'"'"'; __file__='"'"'/tmp/pip-install-bcduayqd/llvmlite_7ddfea482a25471e8f6e44e0fb54a699/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-unqu4w6u
       cwd: /tmp/pip-install-bcduayqd/llvmlite_7ddfea482a25471e8f6e44e0fb54a699/
  Complete output (11 lines):
  running bdist_wheel
  /usr/bin/python3 /tmp/pip-install-bcduayqd/llvmlite_7ddfea482a25471e8f6e44e0fb54a699/ffi/build.py
  LLVM version... Traceback (most recent call last):
    File "/tmp/pip-install-bcduayqd/llvmlite_7ddfea482a25471e8f6e44e0fb54a699/ffi/build.py", line 220, in <module>
      main()
    File "/tmp/pip-install-bcduayqd/llvmlite_7ddfea482a25471e8f6e44e0fb54a699/ffi/build.py", line 210, in main
      main_posix('linux', '.so')
    File "/tmp/pip-install-bcduayqd/llvmlite_7ddfea482a25471e8f6e44e0fb54a699/ffi/build.py", line 134, in main_posix
      raise RuntimeError(msg) from None
  RuntimeError: Could not find a `llvm-config` binary. There are a number of reasons this could occur, please see: https://llvmlite.readthedocs.io/en/latest/admin-guide/install.html#using-pip for help.
  error: command '/usr/bin/python3' failed with exit code 1
  ----------------------------------------
  ERROR: Failed building wheel for llvmlite
```

