### PR TITLE
Rename aminal to Darktile in README/doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Terminal with inline images protocols support:
 | mlterm                |   X11     |   yes         |   Sixel   |
 | kitty                 |   X11     |   yes         |   Kitty   |
 | wezterm               |   X11     |   yes         |   IIP     |
-| aminal                |   X11     |   yes         |   Sixel   |
+| Darktile              |   X11     |   yes         |   Sixel   |
 | Jexer                 |   X11     |   yes         |   Sixel   |
 | GNOME Terminal        |   X11     |   [in-progress](https://gitlab.gnome.org/GNOME/vte/-/issues/253) |   Sixel   |
 | alacritty             |   X11     |   [in-progress](https://github.com/alacritty/alacritty/issues/910) |  Sixel   |

--- a/doc/terminal-images.md
+++ b/doc/terminal-images.md
@@ -29,7 +29,7 @@ The map view currently supports three formats:
 | mlterm                |   X11     |   yes         |   Sixel   |
 | kitty                 |   X11     |   yes         |   Kitty   |
 | wezterm               |   X11     |   yes         |   IIP     |
-| aminal                |   X11     |   yes         |   Sixel   |
+| Darktile              |   X11     |   yes         |   Sixel   |
 | Jexer                 |   X11     |   yes         |   Sixel   |
 | GNOME Terminal        |   X11     |   [in-progress](https://gitlab.gnome.org/GNOME/vte/-/issues/253) |   Sixel   |
 | alacritty             |   X11     |   [in-progress](https://github.com/alacritty/alacritty/issues/910) |  Sixel   |


### PR DESCRIPTION
aminal changed its name for Darktile, see https://github.com/liamg/darktile#what-happened-to-aminal  
This PR just changes it in README.md and doc/terminal-images.md 