### PR TITLE
Make "Weather:" line use Nerd Fonts with v2d/v2n, and fix v2d to use day icons

### DIFF
--- a/lib/view/line.py
+++ b/lib/view/line.py
@@ -25,7 +25,7 @@ from astral.sun import sun
 
 import pytz
 
-from constants import WWO_CODE, WEATHER_SYMBOL, WIND_DIRECTION, WEATHER_SYMBOL_WIDTH_VTE, WEATHER_SYMBOL_PLAIN
+from constants import WWO_CODE, WEATHER_SYMBOL, WEATHER_SYMBOL_WI_NIGHT, WEATHER_SYMBOL_WI_DAY, WIND_DIRECTION, WIND_DIRECTION_WI, WEATHER_SYMBOL_WIDTH_VTE, WEATHER_SYMBOL_PLAIN
 from weather_data import get_weather_data
 from . import v2
 from . import v3
@@ -81,8 +81,21 @@ def render_condition(data, query):
     """Emoji encoded weather condition (c)
     """
 
-    weather_condition = WEATHER_SYMBOL[WWO_CODE[data['weatherCode']]]
-    spaces = " "*(WEATHER_SYMBOL_WIDTH_VTE.get(weather_condition) - 1)
+    if query.get("view") == "v2n":
+        weather_condition = WEATHER_SYMBOL_WI_NIGHT.get(
+                WWO_CODE.get(
+                    data['weatherCode'], "Unknown"))
+        spaces = "  "
+    elif query.get("view") == "v2d":
+        weather_condition = WEATHER_SYMBOL_WI_DAY.get(
+                WWO_CODE.get(
+                    data['weatherCode'], "Unknown"))
+        spaces = "  "
+    else:
+        weather_condition = WEATHER_SYMBOL.get(
+                WWO_CODE.get(
+                    data['weatherCode'], "Unknown"))
+        spaces = " "*(3 - WEATHER_SYMBOL_WIDTH_VTE.get(weather_condition, 1))
 
     return weather_condition + spaces
 
@@ -170,7 +183,10 @@ def render_wind(data, query):
         degree = ""
 
     if degree:
-        wind_direction = WIND_DIRECTION[int(((degree+22.5)%360)/45.0)]
+        if query.get("view") in ["v2n", "v2d"]:
+            wind_direction = WIND_DIRECTION_WI[int(((degree+22.5)%360)/45.0)]
+        else:
+            wind_direction = WIND_DIRECTION[int(((degree+22.5)%360)/45.0)]
     else:
         wind_direction = ""
 

--- a/lib/view/v2.py
+++ b/lib/view/v2.py
@@ -321,7 +321,7 @@ def draw_emoji(data, config):
         weather_symbol = constants.WEATHER_SYMBOL_WI_NIGHT
         weather_symbol_width_vte = constants.WEATHER_SYMBOL_WIDTH_VTE_WI
     elif config.get("view") == "v2d":
-        weather_symbol = constants.WEATHER_SYMBOL_WI_NIGHT
+        weather_symbol = constants.WEATHER_SYMBOL_WI_DAY
         weather_symbol_width_vte = constants.WEATHER_SYMBOL_WIDTH_VTE_WI
     else:
         weather_symbol = constants.WEATHER_SYMBOL


### PR DESCRIPTION
As discovered in #363, the "Weather:" line still uses emojis even in v2d/v2n views. Hopefully this (commit 2f18e8a) fixes it, as well as the one-line output when using v2d/v2n, which also still outputs weather icons in emojis.

Additionally, I found that v2d for some reason uses WEATHER_SYMBOL_WI_NIGHT icons; I have fixed that as well in a different commit (556559a), but I felt it was too small a change to be submitted as a separate pull request, so I decided to include it in this pull request as well.

Do let me know what you think!