### PR TITLE
Add "plaintext" handling for httpx client

### DIFF
--- a/cmd/srv.go
+++ b/cmd/srv.go
@@ -23,6 +23,7 @@ var plainTextAgents = []string{
 	"httpie",
 	"lwp-request",
 	"wget",
+	"python-httpx",
 	"python-requests",
 	"openbsd ftp",
 	"powershell",


### PR DESCRIPTION
https://www.python-httpx.org is another python http client, similar to requests, it has a CLI interface.