### PR TITLE
Ensure `M` enables metric

### DIFF
--- a/lib/parse_query.py
+++ b/lib/parse_query.py
@@ -84,6 +84,7 @@ def parse_query(args):
     if 'm' in q:
         result['use_metric'] = True
     if 'M' in q:
+        result['use_metric'] = True
         result['use_ms_for_wind'] = True
     if 'u' in q:
         result['use_imperial'] = True


### PR DESCRIPTION
It seems reasonable, per the documentation (under the section, "Weather Units"), that `?M` would enable metric ("metric (SI), but show wind speed in m/s") all by itself.

> By default the USCS units are used for the queries from the USA and the metric system for the rest of the world. You can override this behavior...
> ...
> `curl wttr.in/Amsterdam?M`  # metric (SI), but show wind speed in m/s

In the USA, we have to pass `?m&M` (`https://wttr.in/?m&M`) to get metric and meters/second. If we just pass `?M`, we get USCS units for everything else and windspeed in meters/second.