### PR TITLE
Add Catalan to v2 footer strings.

### DIFF
--- a/lib/translations_v2.py
+++ b/lib/translations_v2.py
@@ -15,7 +15,7 @@ V2_TRANSLATION = {
     "bg": ("Прогноза за времето в:",        "", "", "", "", "", "", "", ""),
     "bn" : ("আবহাওয়া প্রতিবেদন:", "আবহাওয়া", "টাইমজোন", "এখন", "ভোর", "সূর্যোদয়", "সুবিন্দু", "সূর্যাস্ত", "সন্ধ্যা"),
     "bs": ("Vremenske prognoze za:",        "", "", "", "", "", "", "", ""),
-    "ca": ("Informe del temps per a:",      "", "", "", "", "", "", "", ""),
+    "ca": ("Informe del temps per a:",      "Oratge", "Zona horària", "Ara", "Albada", "Sortida", "Zenit", "Posta", "Crepuscle"),
     "cs": ("Předpověď počasí pro:",         "", "", "", "", "", "", "", ""),
     "cy": ("Adroddiad tywydd ar gyfer:",    "", "", "", "", "", "", "", ""),
     "da": ("Vejret i:",                     "Vejret", "Tidszone", "Nu", "Daggry", "Solopgang", "Zenit", "Solnedgang", "Skumring"),


### PR DESCRIPTION
Notice, I'm using "[Oratge](https://ca.wiktionary.org/wiki/oratge)" instead of "[Temps](https://ca.wiktionary.org/wiki/temps)":
* "Oratge" is unambiguously referring to weather, as opposed to "Temps" which might refer to both "Weather" and "Time (lapse)".
* It's used both in Catalonia (Catalan) and Valencia (Valencian), which share ISO code (see ["cat" ISO 639-2 code](https://www.loc.gov/standards/iso639-2/php/langcodes_name.php?code_ID=75)).