### PR TITLE
Fix Python dependency API risk issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ astral
 timezonefinder==2.1.2
 pytz
 pyte
-python-dateutil
+python-dateutil>=2.5.0,<=2.6.1
 diagram
 pyjq
 scipy


### PR DESCRIPTION
Fix issue #765 by change dependency **python-dateutil** version constraint to **>=2.5.0,<=2.6.1**.