### PR TITLE
docs(README): Clean up code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,9 +581,9 @@ wttr.in has the following external dependencies:
 * [wego](https://github.com/schachmat/wego), weather client for terminal
 
 After you install [golang](https://golang.org/doc/install), install `wego`:
-
-    $ go get -u github.com/schachmat/wego
-    $ go install github.com/schachmat/wego
+```bash
+go install github.com/schachmat/wego@latest
+```
 
 ### Install Python dependencies
 
@@ -605,13 +605,15 @@ You can install most of them using `pip`.
 
 Some python package use LLVM, so install it first:
 
-    $ apt-get install llvm-7 llvm-7-dev
-
+```bash
+apt-get install llvm-7 llvm-7-dev
+```
 If `virtualenv` is used:
-
-    $ virtualenv -p python3 ve
-    $ ve/bin/pip3 install -r requirements.txt
-    $ ve/bin/python3 bin/srv.py
+```bash
+virtualenv -p python3 ve
+ve/bin/pip3 install -r requirements.txt
+ve/bin/python3 bin/srv.py
+```
 
 Also, you need to install the geoip2 database.
 You can use a free database GeoLite2 that can be downloaded from (http://dev.maxmind.com/geoip/geoip2/geolite2/).


### PR DESCRIPTION
[Rendered Markdown](https://github.com/jidicula/wttr.in/blob/patch-2/README.md)

Removes prompt character in code blocks so when it's rendered on GitHub, the copy button is useful for quick pasting in the terminal.

Also updates the go installation commands for the wego dependency setup - `go get` is no longer supported outside a module, and the `go install` command needs to reference a specific git reference.