### PR TITLE
fix spelling (#822)

### DIFF
--- a/lib/fields.py
+++ b/lib/fields.py
@@ -30,7 +30,7 @@ DESCRIPTION = {
         "Temperature in Fahrenheit",
         "temperature_fahrenheit"),
     "uvIndex": (
-        "Ultaviolet Radiation Index",
+        "Ultraviolet Radiation Index",
         "uv_index"),
     "visibility": (
         "Visible Distance in Kilometres",
@@ -91,15 +91,15 @@ DESCRIPTION = {
 
     # astronomy fields with time
     "moonrise": (
-        "Minutes since start of the day untill the moon appears above the horizon",
+        "Minutes since start of the day until the moon appears above the horizon",
         "astronomy_moonrise_min"),
     "moonset": (
-        "Minutes since start of the day untill the moon disappears below the horizon",
+        "Minutes since start of the day until the moon disappears below the horizon",
         "astronomy_moonset_min"),
     "sunrise": (
-        "Minutes since start of the day untill the sun appears above the horizon",
+        "Minutes since start of the day until the sun appears above the horizon",
         "astronomy_sunrise_min"),
     "sunset": (
-        "Minutes since start of the day untill the moon disappears below the horizon",
+        "Minutes since start of the day until the moon disappears below the horizon",
         "astronomy_sunset_min"),
     }


### PR DESCRIPTION
This is a pull request to fix #822, where
> the words “ultraviolet” and “until” are misspelled `/lib/fields.py`:
>
> - https://github.com/chubin/wttr.in/blob/dabfc55c8be1d793e355c7023f3345533ee16be3/lib/fields.py#L33
> - https://github.com/chubin/wttr.in/blob/dabfc55c8be1d793e355c7023f3345533ee16be3/lib/fields.py#L94
> - https://github.com/chubin/wttr.in/blob/dabfc55c8be1d793e355c7023f3345533ee16be3/lib/fields.py#L97
> - https://github.com/chubin/wttr.in/blob/8dc0e08f5e38ff1cc7aca8377019750c0284ce9d/lib/fields.py#L100
> - https://github.com/chubin/wttr.in/blob/dabfc55c8be1d793e355c7023f3345533ee16be3/lib/fields.py#L103