### PR TITLE
set application stage image to alpine:3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN go get -u github.com/mattn/go-colorable && \
     cd /app && CGO_ENABLED=0 go build .
 
 # Application stage
-FROM alpine:3
+FROM alpine:3.16
 
 WORKDIR /app
 


### PR DESCRIPTION
I'm unable to build past the application stage due to missing llvm11-dev in alpine branch used by alpine:3 (which is alpine:3.18).

You can verify that llvm11-dev is not available in 3.18 here: https://pkgs.alpinelinux.org/packages?name=llvm11-dev&branch=edge&repo=&arch=x86&maintainer=

To successfully build. [I looked up the newest branch with llvm11-dev (3.16)](https://pkgs.alpinelinux.org/packages?name=llvm11-dev&branch=v3.16&repo=&arch=x86&maintainer=) and set the application stage base image to alpine:3.16.

In case anyone managed to build this successfully somehow as-is, I've attached my build logs. 

[alpine-3.16-build-log.txt](https://github.com/chubin/wttr.in/files/11973411/alpine-3.16-build-log.txt)
[alpine-3-build-log.txt](https://github.com/chubin/wttr.in/files/11973412/alpine-3-build-log.txt)

