### PR TITLE
Introduce 'dumb' mode for terminals without fallback glyphs

### DIFF
--- a/lib/globals.py
+++ b/lib/globals.py
@@ -94,6 +94,14 @@ PLAIN_TEXT_AGENTS = [
 
 PLAIN_TEXT_PAGES = [':help', ':bash.function', ':translation', ':iterm2']
 
+TRANSLATION_TABLE = str.maketrans({
+    '\u2196': '\u256E',  # '↖' -> '╮'
+    '\u2197': '\u256D',  # '↗' -> '╭'
+    '\u2198': '\u2570',  # '↘' -> '╰'
+    '\u2199': '\u256F',  # '↙' -> '╯'
+    '\u26A1': '\u250C\u2518'
+})
+
 _IPLOCATION_ORDER = os.environ.get(
     "WTTR_IPLOCATION_ORDER",
     'geoip,ip2location,ipinfo')

--- a/lib/parse_query.py
+++ b/lib/parse_query.py
@@ -79,6 +79,8 @@ def parse_query(args):
         return result
     if 'A' in q:
         result['force-ansi'] = True
+    if 'd' in q:
+        result['dumb'] = True
     if 'n' in q:
         result['narrow'] = True
     if 'm' in q:

--- a/lib/view/moon.py
+++ b/lib/view/moon.py
@@ -44,6 +44,9 @@ def get_moon(parsed_query):
     if parsed_query.get('no-terminal', False):
         stdout = globals.remove_ansi(stdout)
 
+    if parsed_query.get('dumb', False):
+        stdout = stdout.translate(globals.TRANSLATION_TABLE)
+
     if html:
         p = Popen(
             ["bash", globals.ANSI2HTML, "--palette=solarized", "--bg=dark"],

--- a/lib/view/v2.py
+++ b/lib/view/v2.py
@@ -38,7 +38,7 @@ from astral import moon, sun
 from scipy.interpolate import interp1d
 from babel.dates import format_datetime
 
-from globals import WWO_KEY, remove_ansi
+from globals import WWO_KEY, TRANSLATION_TABLE, remove_ansi
 import constants
 import translations
 import parse_query
@@ -638,6 +638,8 @@ def main(query, parsed_query, data):
             output += textual_information(data_parsed, geo_data, parsed_query)
         if parsed_query.get('no-terminal', False):
             output = remove_ansi(output)
+        if parsed_query.get('dumb', False):
+            output = output.translate(TRANSLATION_TABLE)
     return output
 
 if __name__ == '__main__':

--- a/lib/view/wttr.py
+++ b/lib/view/wttr.py
@@ -13,8 +13,8 @@ from gevent.subprocess import Popen, PIPE
 
 sys.path.insert(0, "..")
 from translations import get_message, SUPPORTED_LANGS
-from globals import WEGO, NOT_FOUND_LOCATION, DEFAULT_LOCATION, ANSI2HTML, \
-                    error, remove_ansi
+from globals import WEGO, TRANSLATION_TABLE, NOT_FOUND_LOCATION, \
+                    DEFAULT_LOCATION, ANSI2HTML, error, remove_ansi
 
 
 def get_wetter(parsed_query):
@@ -125,6 +125,9 @@ def _wego_postprocessing(location, parsed_query, stdout):
 
     if parsed_query.get('no-city', False):
         stdout = "\n".join(stdout.splitlines()[2:]) + "\n"
+
+    if parsed_query.get('dumb', False):
+        stdout = stdout.translate(TRANSLATION_TABLE)
 
     if full_address \
         and parsed_query.get('format', 'txt') != 'png' \

--- a/lib/wttr_srv.py
+++ b/lib/wttr_srv.py
@@ -17,7 +17,7 @@ import fmt.png
 import parse_query
 from translations import get_message, FULL_TRANSLATION, PARTIAL_TRANSLATION, SUPPORTED_LANGS
 from buttons import add_buttons
-from globals import get_help_file, remove_ansi, \
+from globals import get_help_file, remove_ansi, TRANSLATION_TABLE, \
                     BASH_FUNCTION_FILE, TRANSLATION_FILE, LOG_FILE, \
                     NOT_FOUND_LOCATION, \
                     MALFORMED_RESPONSE_HTML_PAGE, \
@@ -239,6 +239,8 @@ def _response(parsed_query, query, fast_mode=False):
                 message = get_message('FOLLOW_ME', parsed_query['lang'])
                 if parsed_query.get('no-terminal', False):
                     message = remove_ansi(message)
+                if parsed_query.get('dumb', False):
+                    message = message.translate(TRANSLATION_TABLE)
                 output += '\n' + message + '\n'
 
     return cache.store(cache_signature, output)


### PR DESCRIPTION
Windows' native terminal, `conhost.exe`, lacks font fallback support. This causes some of the characters used in `wttr.in`'s terminal output to not be displayed at all - placeholders are supplied in their place. This PR provides a mode that, when enabled, translates missing glyphs to ones available on every platform without (*I believe*) making any compromises regarding their meaning; see translation table below.

| Character        | C-UCP  | Replacements                          | R-UCPs |
| :--------------- | :----: | :------------------------------------ | :----: |
| NORTH WEST ARROW | U+2196 | BOX DRAWINGS LIGHT ARC DOWN AND LEFT  | U+256E |
| NORTH EAST ARROW | U+2197 | BOX DRAWINGS LIGHT ARC DOWN AND RIGHT | U+256D |
| SOUTH EAST ARROW | U+2198 | BOX DRAWINGS LIGHT ARC UP AND RIGHT   | U+2570 |
| SOUTH WEST ARROW | U+2199 | BOX DRAWINGS LIGHT ARC UP AND LEFT    | U+256F |
| HIGH VOLTAGE SIGN | U+26A1 | BOX DRAWINGS LIGHT DOWN AND RIGHT + UP AND LEFT | U+250C + U+2518 |

Admittedly `dumb` is a placeholder - I have no idea how to name this. Could we discuss this before (if) proceeding further?

Fixes #18.

As a quick demo, here's how it looks like on my terminal:

![cmd_Dyll3wA4eO](https://github.com/chubin/wttr.in/assets/7210216/8e65d540-117d-4bdf-8a40-1b05389605b0)