### PR TITLE
Add `nushell` agent

### DIFF
--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -37,6 +37,7 @@ func plainTextAgents() []string {
 		"aiohttp",
 		"http_get",
 		"xh",
+		"nushell",
 	}
 }
 

--- a/lib/globals.py
+++ b/lib/globals.py
@@ -90,6 +90,7 @@ PLAIN_TEXT_AGENTS = [
     "aiohttp",
     "http_get",
     "xh",
+    "nushell",
 ]
 
 PLAIN_TEXT_PAGES = [':help', ':bash.function', ':translation', ':iterm2']


### PR DESCRIPTION
[Nushell](https://www.nushell.sh/) is the shell with built-in HTTP client, identified by `nushell` user-agent string:

https://github.com/nushell/nushell/blob/19d732f313c4def195ce11474b165d75657e96cb/crates/nu-command/src/network/http/client.rs#L38C22-L38C29
