### PR TITLE
Update documentation regarding fallback glyphs mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ intended to demonstrate the power of the console-oriented services,
 
 You can see it running here: [wttr.in](https://wttr.in).
 
-[Documentation](https://wttr.in/:help) | [Usage](https://github.com/chubin/wttr.in#usage) | [One-line output](https://github.com/chubin/wttr.in#one-line-output) | [Data-rich output format](https://github.com/chubin/wttr.in#data-rich-output-format-v2) | [Map view](https://github.com/chubin/wttr.in#map-view-v3) | [Output formats](https://github.com/chubin/wttr.in#different-output-formats) | [Moon phases](https://github.com/chubin/wttr.in#moon-phases) | [Internationalization](https://github.com/chubin/wttr.in#internationalization-and-localization) | [Windows issues](https://github.com/chubin/wttr.in#windows-users) | [Installation](https://github.com/chubin/wttr.in#installation)
+[Documentation](https://wttr.in/:help) | [Usage](https://github.com/chubin/wttr.in#usage) | [One-line output](https://github.com/chubin/wttr.in#one-line-output) | [Data-rich output format](https://github.com/chubin/wttr.in#data-rich-output-format-v2) | [Map view](https://github.com/chubin/wttr.in#map-view-v3) | [Output formats](https://github.com/chubin/wttr.in#different-output-formats) | [Moon phases](https://github.com/chubin/wttr.in#moon-phases) | [Internationalization](https://github.com/chubin/wttr.in#internationalization-and-localization) | [Installation](https://github.com/chubin/wttr.in#installation)
 
 ## Usage
 
@@ -75,7 +75,6 @@ To get detailed information online, you can access the [/:help](https://wttr.in/
 
     $ curl wttr.in/:help
 
-
 ### Weather Units
 
 By default the USCS units are used for the queries from the USA and the metric system for the rest of the world.
@@ -108,6 +107,10 @@ The ANSI and HTML formats are selected based on the User-Agent string.
 To force plain text, which disables colors:
 
     $ curl wttr.in/?T
+
+To restrict output to glyphs available in standard console fonts (e.g. Consolas and Lucida Console):
+
+    $ curl wttr.in/?d
 
 The PNG format can be forced by adding `.png` to the end of the query:
 
@@ -547,19 +550,6 @@ to see the list of supported languages and contributors, or to know how you can 
 in your language.
 
 ![Queries to wttr.in in various languages](https://pbs.twimg.com/media/C7hShiDXQAES6z1.jpg)
-
-## Windows Users
-
-There are currently two Windows related issues that prevent the examples found on this page from working exactly as expected out of the box. Until Microsoft fixes the issues, there are a few workarounds. To circumvent both issues you may use a shell such as `bash` on the [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install-win10) or read on for alternative solutions.
-
-### Garbage characters in the output
-There is a limitation of the current Win32 version of `curl`. Until the [Win32 curl issue](https://github.com/chubin/wttr.in/issues/18#issuecomment-474145551) is resolved and rolled out in a future Windows release, it is recommended that you use Powershell’s `Invoke-Web-Request` command instead:
-- `(Invoke-WebRequest https://wttr.in).Content`
-
-### Missing or double wide diagonal wind direction characters
-The second issue is regarding the width of the diagonal arrow glyphs that some Windows Terminal Applications such as the default `conhost.exe` use. At the time of writing this, `ConEmu.exe`, `ConEmu64.exe` and Terminal Applications built on top of ConEmu such as Cmder (`cmder.exe`) use these double-wide glyphs by default. The result is the same with all of these programs, either a missing character for certain wind directions or a broken table in the output or both. Some third-party Terminal Applications have addressed the wind direction glyph issue but that fix depends on the font and the Terminal Application you are using.
-One way to display the diagonal wind direction glyphs in your Terminal Application is to use [Windows Terminal](https://www.microsoft.com/en-us/p/windows-terminal-preview/9n0dx20hk701?activetab=pivot:overviewtab) which is currently available in the [Microsoft Store](https://www.microsoft.com/en-us/p/windows-terminal-preview/9n0dx20hk701?activetab=pivot:overviewtab). Windows Terminal is currently a preview release and will be rolled out as the default Terminal Application in an upcoming release. If your output is still skewed after using Windows Terminal then try maximizing the terminal window.
-Another way you can display the diagonal wind direction is to swap out the problematic characters with forward and backward slashes as shown [here](https://github.com/chubin/wttr.in/issues/18#issuecomment-405640892).
 
 ## Installation
 

--- a/share/help.txt
+++ b/share/help.txt
@@ -30,6 +30,7 @@ View options:
     1                       # current weather + today's forecast
     2                       # current weather + today's + tomorrow's forecast
     A                       # ignore User-Agent and force ANSI output format (terminal)
+    d                       # restrict output to standard console font glyphs
     F                       # do not show the "Follow" line
     n                       # narrow version (only day and night)
     q                       # quiet version (no "Weather report" text)


### PR DESCRIPTION
Added in #906.

Tips for Windows users were removed as they are no longer necessary (and haven't been for a while).