### PR TITLE
Replace CSS colors in favor of basic light/dark mode through meta tag

### DIFF
--- a/share/static/style.css
+++ b/share/static/style.css
@@ -1,7 +1,3 @@
-body {
-    background: black;
-    color: #bbbbbb;
-}
 pre {
 /*    font-family: source_code_proregular; */
 

--- a/share/templates/index.html
+++ b/share/templates/index.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta name="color-scheme" content="light dark">
 <link rel="stylesheet" type="text/css" href="https://adobe-fonts.github.io/source-code-pro/source-code-pro.css">
 <link rel="stylesheet" type="text/css" href="/files/style.css" />
 </head>


### PR DESCRIPTION
The site had their colors explicitly set to dark through their CSS. However, if removing those strict colors and instead declaring the [`theme-color` in HTML meta tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color), you can have a basic but effective dark mode:

![Screenshot from 2024-03-20 12-45-23](https://github.com/chubin/wttr.in/assets/476060/c7f6b181-f2fb-4965-a20b-e7b7166865b5)
![Screenshot from 2024-03-20 12-45-15](https://github.com/chubin/wttr.in/assets/476060/99d566c1-5891-43d9-a562-76304f4d02fa)
