### PR TITLE
Resolved errors with README images failing to load

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ or, if you prefer Nerd Fonts instead of Emoji, `v2d` (day) or `v2n` (night):
 ```
 
 
-![data-reach output format](https://wttr.in/files/example-wttr-v2.png)
+![data-rich output format](https://wttr.in/files/example-wttr-v2.png)
 
 (The mode is experimental, and it has several limitations currently:
 

--- a/srv.go
+++ b/srv.go
@@ -262,5 +262,5 @@ func setLogLevel(logLevel string) error {
 
 func checkURLForPNG(r *http.Request) bool {
 	url := r.URL.String()
-	return strings.Contains(url, ".png")
+	return strings.Contains(url, ".png") && !strings.Contains(url, "/files/")
 }


### PR DESCRIPTION
Two images linked in the README are served using wttr.in URLs:
- [wttr.in in tmux status bar](https://wttr.in/files/example-tmux-status-line.png)
- [data-reach output format*](https://wttr.in/files/example-wttr-v2.png)

These images are blocked when PNG support is disabled. 

I updated the `checkURLForPNG` function to ignore paths that match the `/files/` directory.

\* I also updated the alt text for `data-reach output format` to `data-rich output format` 