### PR TITLE
Consider missing/empty agent to be plaintext

### DIFF
--- a/lib/globals.py
+++ b/lib/globals.py
@@ -78,6 +78,7 @@ PROXY_CACHEDIR = os.path.join(_DATADIR, "cache/proxy-wwo/")
 MY_EXTERNAL_IP = '5.9.243.187'
 
 PLAIN_TEXT_AGENTS = [
+    "",
     "curl",
     "httpie",
     "lwp-request",


### PR DESCRIPTION
This PR adds `""` (empty string) to the `PLAIN_TEXT_AGENTS` list.

This means that a client that doesn't set the user-agent header at all (or sets it to an empty string) will be treated as plaintext.

Rationale: A client that doesn't set the UA is likely to be bare-bones, and therefore likely plaintext.