### PR TITLE
Fix bash-function: Fix under zsh

### DIFF
--- a/share/bash-function.txt
+++ b/share/bash-function.txt
@@ -20,7 +20,7 @@ fi
 
 wttr() {
   local location="${1// /+}"
-  command shift
+  shift
   local args=""
   for p in $WTTR_PARAMS "$@"; do
     args+=" --data-urlencode $p "

--- a/share/bash-function.txt
+++ b/share/bash-function.txt
@@ -20,7 +20,7 @@ fi
 
 wttr() {
   local location="${1// /+}"
-  shift
+  test "$#" -gt 0 && shift
   local args=""
   for p in $WTTR_PARAMS "$@"; do
     args+=" --data-urlencode $p "

--- a/share/bash-function.txt
+++ b/share/bash-function.txt
@@ -21,11 +21,11 @@ fi
 wttr() {
   local location="${1// /+}"
   test "$#" -gt 0 && shift
-  local args=""
+  local args=()
   for p in $WTTR_PARAMS "$@"; do
-    args+=" --data-urlencode $p "
+    args+=("--data-urlencode" "$p")
   done
-  curl -fGsS -H "Accept-Language: ${LANG%_*}" $args --compressed "wttr.in/${location}"
+  curl -fGsS -H "Accept-Language: ${LANG%_*}" "${args[@]}" --compressed "wttr.in/${location}"
 }
 
 wttr "$@"


### PR DESCRIPTION
- [x] Fix for "zsh: command not found: shift":
- [x] Fix "curl: (3) URL using bad/illegal format or missing URL"

Tested with:

```
❯ bash --version
GNU bash, version 5.2.32(1)-release (aarch64-apple-darwin23.4.0)
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

❯ sh --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin23)
Copyright (C) 2007 Free Software Foundation, Inc.

❯ zsh --version
zsh 5.9 (x86_64-apple-darwin23.0)
```


Refs:
- https://github.com/chubin/wttr.in/issues/853