### PR TITLE
(Re)enable PNG responses

### DIFF
--- a/bin/proxy.py
+++ b/bin/proxy.py
@@ -110,7 +110,7 @@ def _cache_file(path, query):
 
     digest = hashlib.sha1(("%s %s" % (path, query)).encode("utf-8")).hexdigest()
     digest_number = ord(digest[0].upper())
-    expiry_interval = 60 * (digest_number + 180)
+    expiry_interval = 60 * (digest_number + 300)
 
     timestamp = "%010d" % (int(time.time()) // expiry_interval * expiry_interval)
     filename = os.path.join(PROXY_CACHEDIR, timestamp, path, query)

--- a/config/services/services.yaml
+++ b/config/services/services.yaml
@@ -30,3 +30,8 @@ services:
     command: "WTTRIN_SRV_PORT=9005 ve/bin/python3 bin/srv.py"
     workdir: "/wttr.in/wttr.in-v2-v2"
     port: 9005
+
+  - name: "filetype=png"
+    command: "WTTRIN_SRV_PORT=9006 ve/bin/python3 bin/srv.py"
+    workdir: "/wttr.in/wttr.in-v2-v2"
+    port: 9006

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,10 @@ type Uplink struct {
 	// for all other queries.
 	Address3 string `yaml:"address3,omitempty"`
 
+	// Address4 contains address of the uplink server in form IP:PORT
+	// for PNG queries.
+	Address4 string `yaml:"address4,omitempty"`
+
 	// Timeout for upstream queries.
 	Timeout int `yaml:"timeout,omitempty"`
 
@@ -152,6 +156,7 @@ func Default() *Config {
 			Address1:         "127.0.0.1:9002",
 			Address2:         "127.0.0.1:9002",
 			Address3:         "127.0.0.1:9002",
+			Address4:         "127.0.0.1:9002",
 			Timeout:          30,
 			PrefetchInterval: 300,
 		},

--- a/internal/processor/j1.go
+++ b/internal/processor/j1.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func getAny(req *http.Request, tr1, tr2, tr3 *http.Transport) (*ResponseWithHeader, error) {
+func getAny(req *http.Request, tr1, tr2, tr3, tr4 *http.Transport) (*ResponseWithHeader, error) {
 	uri := strings.ReplaceAll(req.URL.RequestURI(), "%", "%25")
 
 	u, err := url.Parse(uri)
@@ -27,6 +27,10 @@ func getAny(req *http.Request, tr1, tr2, tr3 *http.Transport) (*ResponseWithHead
 
 	// log.Println(req.URL.Query())
 	// log.Println()
+
+	if checkURLForPNG(req) {
+		return getDefault(req, tr4)
+	}
 
 	return getDefault(req, tr3)
 }
@@ -86,4 +90,9 @@ func getUpstream(req *http.Request, transport *http.Transport) (*ResponseWithHea
 		Header:     res.Header,
 		StatusCode: res.StatusCode,
 	}, nil
+}
+
+func checkURLForPNG(r *http.Request) bool {
+	url := r.URL.String()
+	return strings.Contains(url, ".png") && !strings.Contains(url, "/files/")
 }

--- a/srv.go
+++ b/srv.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	stdlog "log"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -156,12 +155,6 @@ func mainHandler(
 			log.Println(err)
 		}
 
-		if checkURLForPNG(r) {
-			w.Write([]byte("PNG support temporary disabled"))
-
-			return
-		}
-
 		response, err := rp.ProcessRequest(r)
 		if err != nil {
 			log.Println(err)
@@ -258,9 +251,4 @@ func setLogLevel(logLevel string) error {
 	log.SetLevel(parsedLevel)
 
 	return nil
-}
-
-func checkURLForPNG(r *http.Request) bool {
-	url := r.URL.String()
-	return strings.Contains(url, ".png") && !strings.Contains(url, "/files/")
 }


### PR DESCRIPTION
PNG support, which was disabled for a certain period of time, is re-enabled.

To run PNG queries, append `.png` to the end of the URL.

For example, to get forecast for Berlin (https://wttr.in/Berlin) as a PNG file:

`https://wttr.in/Berlin.png`

Fixes #919 
Fixes #928 