### PR TITLE
fix: add node to plain text agents

### DIFF
--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -38,6 +38,7 @@ func plainTextAgents() []string {
 		"xh",
 		"nushell",
 		"zig",
+		"node",
 	}
 }
 


### PR DESCRIPTION
Running fetch inside node uses node as UA by default

```
% node                                                                         
Welcome to Node.js v24.4.1.
Type ".help" for more information.
> console.log(await (await fetch('https://ifconfig.me/ua')).text());
node
undefined
> 
```