### PR TITLE
Weather symbols for nerd fonts

### DIFF
--- a/lib/constants.py
+++ b/lib/constants.py
@@ -73,6 +73,27 @@ WEATHER_SYMBOL = {
     "VeryCloudy": "☁️",
 }
 
+WEATHER_SYMBOL_NERDFONTS = {
+    "Cloudy": "\U000f0590",             # nf-md-weather_cloudy
+    "VeryCloudy": "\U000f0590",             # nf-md-weather_cloudy
+    "Fog": "\U000f0591",                 # nf-md-weather_fog
+    "HeavyRain": "\U000f0596",           # nf-md-weather_pouring
+    "HeavyShowers": "\U000f0596",           # nf-md-weather_pouring
+    "HeavySnow": "\U000f0f36",           # nf-md-weather_snowy_heavy
+    "HeavySnowShowers": "\U000f067f",    # nf-md-weather_snowy_rainy
+    "LightRain": "\U000f0597",           # nf-md-weather_rainy
+    "LightShowers": "\U000f0597",           # nf-md-weather_rainy
+    "LightSleet": "\U000f067f",          # nf-md-weather_snowy_rainy ## Graupel?
+    "LightSleetShowers": "\U000f067f",          # nf-md-weather_snowy_rainy ## Graupel?
+    "LightSnow": "\U000f0598",           # nf-md-weather_snowy
+    "LightSnowShowers": "\U000f067f",          # nf-md-weather_snowy_rainy
+    "PartlyCloudy": "\U000f0595",        # nf-md-weather_partly_cloudy
+    "Sunny": "\U000f0599",               # nf-md-weather_sunny
+    "ThunderyHeavyRain": "\U000f067e",   # nf-md-weather_lightning_rainy
+    "ThunderyShowers": "\U000f067e",   # nf-md-weather_lightning_rainy
+}
+
+
 WEATHER_SYMBOL_WIDTH_VTE = {
     "✨": 2,
     "☁️": 1,


### PR DESCRIPTION
For implementing #1147.

As a first step I got the weather symbols I could find from the nerd fonts website. I decided to list them as escape sequences rather than symbols, because otherwise every developer who doesn't have nerd fonts installed will only see squares and have a hard time distinguishing one symbol from the other.

Unknown and Thunder Snow Showers didn't make it into the list as I didn't find a corresponding symbol.

As I don't have a running server side (with keys to weather api servers) I'm not sure how I could test changing the API to allow nerd fonts output.