### PR TITLE
Add dew point format specifier (%e)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ To specify your own custom output format, use the special `%`-notation:
     M    Moon day,
     p    Precipitation (mm/3 hours),
     P    Pressure (hPa),
+    e    Dew point,
     u    UV index (1-12),
 
     D    Dawn*,

--- a/lib/view/line.py
+++ b/lib/view/line.py
@@ -189,6 +189,33 @@ def render_pressure(data, query):
     return answer
 
 
+def render_dewpoint(data, query):
+    """
+    dew point (e)
+    """
+
+    try:
+        temp_c = float(data["temp_C"])
+        humidity = float(data["humidity"])
+    except (KeyError, ValueError, TypeError):
+        return ""
+
+    if not humidity:
+        return ""
+
+    dew_point_c = temp_c - (100.0 - humidity) / 5.0
+
+    if query.get("use_imperial", False):
+        dew_point = "%s°F" % int(round(dew_point_c * 9.0 / 5 + 32))
+    else:
+        dew_point = "%s°C" % int(round(dew_point_c))
+
+    if dew_point[0] != "-":
+        dew_point = "+" + dew_point
+
+    return dew_point
+
+
 def render_uv_index(data, query):
     """
     UV Index (u)
@@ -335,6 +362,7 @@ FORMAT_SYMBOL = {
     "p": render_precipitation,
     "o": render_precipitation_chance,
     "P": render_pressure,
+    "e": render_dewpoint,
     "u": render_uv_index,
 }
 


### PR DESCRIPTION
I use wttr.in a lot for sailing and one thing I keep missing is dew point. It's a key value when you're out on the water (helps figure out cloud base height, how comfortable it's going to be, and whether fog is likely to roll in).

This adds `%e` to the custom format notation. Dew point is computed from temperature and relative humidity using the approximation formula `Td = T - (100 - RH) / 5`, so it works with both the WWO and met.no backends without needing extra API fields.

**Usage:**
```
curl wttr.in/London?format=%e       # e.g. +12°C
curl wttr.in/London?format=%e&u     # e.g. +54°F
```