### PR TITLE
Fix zh-tw translation and help text query parameter prefixes

### DIFF
--- a/share/help.txt
+++ b/share/help.txt
@@ -20,28 +20,28 @@ Moon phase information:
 
 Units:
 
-    m                       # metric (SI) (used by default everywhere except US)
-    u                       # USCS (used by default in US)
-    M                       # show wind speed in m/s
+    ?m                      # metric (SI) (used by default everywhere except US)
+    ?u                      # USCS (used by default in US)
+    ?M                      # show wind speed in m/s
 
 View options:
 
-    0                       # only current weather
-    1                       # current weather + today's forecast
-    2                       # current weather + today's + tomorrow's forecast
-    A                       # ignore User-Agent and force ANSI output format (terminal)
-    d                       # restrict output to standard console font glyphs
-    F                       # do not show the "Follow" line
-    n                       # narrow version (only day and night)
-    q                       # quiet version (no "Weather report" text)
-    Q                       # superquiet version (no "Weather report", no city name)
-    T                       # switch terminal sequences off (no colors)
+    ?0                      # only current weather
+    ?1                      # current weather + today's forecast
+    ?2                      # current weather + today's + tomorrow's forecast
+    ?A                      # ignore User-Agent and force ANSI output format (terminal)
+    ?d                      # restrict output to standard console font glyphs
+    ?F                      # do not show the "Follow" line
+    ?n                      # narrow version (only day and night)
+    ?q                      # quiet version (no "Weather report" text)
+    ?Q                      # superquiet version (no "Weather report", no city name)
+    ?T                      # switch terminal sequences off (no colors)
 
 PNG options:
 
     /paris.png              # generate a PNG file
-    p                       # add frame around the output
-    t                       # transparency 150
+    ?p                      # add frame around the output
+    ?t                      # transparency 150
     transparency=...        # transparency from 0 to 255 (255 = not transparent)
     background=...          # background color in form RRGGBB, e.g. 00aaaa
 

--- a/share/translations/zh-tw.txt
+++ b/share/translations/zh-tw.txt
@@ -18,7 +18,7 @@
 281: 凍毛毛雨                        : Freezing drizzle
 284: 重凍毛毛雨                      : Heavy freezing drizzle
 293: 局部小雨                        : Patchy light rain
-296: 小雨                            : Light 
+296: 小雨                            : Light rain
 299: 有時中雨                        : Moderate rain at times
 302: 中雨                            : Moderate rain
 305: 有時大雨                        : Heavy rain at times


### PR DESCRIPTION
Two small fixes:

1. **zh-tw translation (#1180):** Weather code 296 had its English column truncated to "Light" instead of "Light rain". Matches zh-cn and other translations.

2. **Help text (#1168):** The `:help` page listed query parameters (units, view options, PNG options) without the `?` prefix, making it unclear they are query string parameters. Added `?` to match the combined example already shown on the page (`/Paris?0pq`).