### PR TITLE
Default unknown User-Agents to plain text

### DIFF
--- a/internal/query/fromrequest.go
+++ b/internal/query/fromrequest.go
@@ -109,19 +109,9 @@ func FromRequest(r *http.Request) (*options.Options, error) {
 		opts.Lang = "en"
 	}
 
-	// Step 6: Set User-Agent from header
-	userAgent := r.Header.Get("User-Agent")
-	if userAgent != "" {
-		opts.Agent = userAgent
-		// Determine if it's a plain text client (e.g., curl, wget)
-		if opts.Output == "" {
-			if isPlainTextClient(userAgent) {
-				opts.Output = "text"
-			} else {
-				opts.Output = "html"
-			}
-		}
-	}
+	// Step 6: Set User-Agent from header. Output defaulting based on the
+	// agent is deferred to ApplyAutoFixes, where the view is known.
+	opts.Agent = r.Header.Get("User-Agent")
 
 	// Step 8: Set default transparency for PNG output if applicable
 	if opts.Output == "png" && opts.Transparency == 0 {
@@ -151,6 +141,26 @@ func ApplyAutoFixes(opts *options.Options) {
 	}
 	if opts.View == "j1" || opts.View == "j2" {
 		opts.Output = "json"
+	}
+
+	// Default output based on User-Agent. Compact/line views default to text
+	// for non-browsers (they are primarily consumed by scripts and terminals).
+	// The main views (v1, v2, etc.) only switch to text for known CLI clients,
+	// to preserve the rich HTML experience for anything that might be a browser.
+	if opts.Output == "" && opts.Agent != "" {
+		if opts.View == "line" {
+			if isBrowserClient(opts.Agent) {
+				opts.Output = "html"
+			} else {
+				opts.Output = "text"
+			}
+		} else {
+			if isPlainTextClient(opts.Agent) {
+				opts.Output = "text"
+			} else {
+				opts.Output = "html"
+			}
+		}
 	}
 
 	// USCS and Imperial are, strictly speaking, not the same,
@@ -306,9 +316,15 @@ func isValidView(view string) bool {
 		view == "j2"
 }
 
+// isBrowserClient determines if the User-Agent indicates a web browser.
+// All real browsers include "Mozilla/" in their User-Agent string for
+// historical Netscape-compatibility reasons.
+func isBrowserClient(userAgent string) bool {
+	return strings.Contains(strings.ToLower(userAgent), "mozilla/")
+}
+
 // isPlainTextClient determines if the User-Agent indicates a plain text client like curl or wget.
 func isPlainTextClient(userAgent string) bool {
-	// plainTextAgents contains signatures of the plain-text agents.
 	plainTextAgents := []string{
 		"curl",
 		"httpie",


### PR DESCRIPTION
The recent changes broke my code which used a custom user agent and expected to get plain text from format pages such as https://wttr.in/?format=2. This PR changes the default result for unknown user agents to plaintext.

If you could deploy this change soon, that'll be helpful, thanks.

Fixes #1216.

P.S. I'm not sure if the website is deployed from master or ngf. Let me know if I should update the PR to target master.