### PR TITLE
Add both lang_xx and per-language keys (lang_de, etc.)

### DIFF
--- a/internal/localization/weatherer_translate.go
+++ b/internal/localization/weatherer_translate.go
@@ -2,23 +2,23 @@ package localization
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
-
-	"github.com/chubin/wttr.in/internal/domain"
 )
 
+// TranslateWeather translates weather descriptions and adds both lang_xx and lang_{lang} keys.
 func TranslateWeather(weatherBytes []byte, lang string, l10n L10n) ([]byte, error) {
 	if lang == "" || lang == "en" {
 		return weatherBytes, nil
 	}
 
-	// 1. Deserialize
-	var weather domain.Weather
-	if err := json.Unmarshal(weatherBytes, &weather); err != nil {
-		return nil, err
+	// 1. Unmarshal into map for full flexibility (we need to add dynamic keys)
+	var data map[string]any
+	if err := json.Unmarshal(weatherBytes, &data); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal weather: %w", err)
 	}
 
-	// Helper to translate a condition (by English name or code)
+	// 2. Helper to translate
 	translateCondition := func(english string, codeStr string) string {
 		if english != "" {
 			return l10n.ConditionByName(english)
@@ -26,39 +26,88 @@ func TranslateWeather(weatherBytes []byte, lang string, l10n L10n) ([]byte, erro
 		if code, err := strconv.Atoi(codeStr); err == nil && code != 0 {
 			return l10n.Condition(code)
 		}
-		return english // fallback
+		return english
 	}
 
-	// 2. Translate CurrentCondition
-	for i := range weather.CurrentCondition {
-		cc := &weather.CurrentCondition[i]
+	// 3. Translate Current Condition
+	if currentConditions, ok := data["current_condition"].([]any); ok {
+		for _, ccItem := range currentConditions {
+			if cc, ok := ccItem.(map[string]any); ok {
+				weatherDesc := getValueItems(cc, "weatherDesc")
+				code := getString(cc, "weatherCode")
 
-		// Translate weather description
-		for j := range cc.WeatherDesc {
-			if cc.WeatherDesc[j].Value != "" {
-				// Assuming we populate lang_xx with translation
-				translated := translateCondition(cc.WeatherDesc[j].Value, cc.WeatherCode)
-				cc.LangXX = append(cc.LangXX, domain.ValueItem{Value: translated})
+				var langXX []any
+				var langLang []any // e.g. lang_de
+
+				for _, desc := range weatherDesc {
+					if val, ok := desc["value"].(string); ok && val != "" {
+						translated := translateCondition(val, code)
+
+						item := map[string]any{"value": translated}
+						langXX = append(langXX, item)
+						langLang = append(langLang, item)
+					}
+				}
+
+				cc["lang_xx"] = langXX
+				cc[fmt.Sprintf("lang_%s", lang)] = langLang
 			}
 		}
 	}
 
-	// 3. Translate WeatherDay + Hourly
-	for d := range weather.Weather {
-		day := &weather.Weather[d]
+	// 4. Translate Hourly forecasts
+	if weatherDays, ok := data["weather"].([]any); ok {
+		for _, dayItem := range weatherDays {
+			if day, ok := dayItem.(map[string]any); ok {
+				if hourlyList, ok := day["hourly"].([]any); ok {
+					for _, hourItem := range hourlyList {
+						if hour, ok := hourItem.(map[string]any); ok {
+							weatherDesc := getValueItems(hour, "weatherDesc")
+							code := getString(hour, "weatherCode")
 
-		for h := range day.Hourly {
-			hour := &day.Hourly[h]
+							var langXX []any
+							var langLang []any
 
-			for j := range hour.WeatherDesc {
-				if hour.WeatherDesc[j].Value != "" {
-					translated := translateCondition(hour.WeatherDesc[j].Value, hour.WeatherCode)
-					hour.LangXX = append(hour.LangXX, domain.ValueItem{Value: translated})
+							for _, desc := range weatherDesc {
+								if val, ok := desc["value"].(string); ok && val != "" {
+									translated := translateCondition(val, code)
+
+									item := map[string]any{"value": translated}
+									langXX = append(langXX, item)
+									langLang = append(langLang, item)
+								}
+							}
+
+							hour["lang_xx"] = langXX
+							hour[fmt.Sprintf("lang_%s", lang)] = langLang
+						}
+					}
 				}
 			}
 		}
 	}
 
-	// 5. Serialize back
-	return json.Marshal(weather)
+	// 5. Marshal back
+	return json.Marshal(data)
+}
+
+// Helper functions
+func getValueItems(m map[string]any, key string) []map[string]any {
+	if arr, ok := m[key].([]any); ok {
+		result := make([]map[string]any, 0, len(arr))
+		for _, item := range arr {
+			if obj, ok := item.(map[string]any); ok {
+				result = append(result, obj)
+			}
+		}
+		return result
+	}
+	return nil
+}
+
+func getString(m map[string]any, key string) string {
+	if s, ok := m[key].(string); ok {
+		return s
+	}
+	return ""
 }


### PR DESCRIPTION
TranslateWeather now populates both:
- `lang_xx` (standardized key used by wttr.in)
- `lang_{lang}` (e.g. lang_de, lang_fr) for backward compatibility

This restores compatibility with clients that expect the old per-language keys while following the new recommended schema.

- Switched to map-based JSON handling for dynamic key support
- Updated CurrentCondition and Hourly sections
- Preserves original weatherDesc field unchanged

Related: #1237