### PR TITLE
docs: fix broken image link in README Map view section

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ weather information about a geographical region is available:
     $ curl v3.wttr.in/Bayern.sxl
 ```
 
-![v3.wttr.in/Bayern](https://v3.wttr.in/Bayern.png)
+![Example of v3 map view](share/pics/San_Francisco.png)
 
 or directly in browser:
 


### PR DESCRIPTION
## Summary of Changes
- Fixed broken image link in the "Map view (v3)" section of README.md
- Replaced the dynamic service URL with a static repo-hosted image

## Root Cause
The v3.wttr.in/Bayern.png endpoint returns "Error Fetching Resource" intermittently due to service availability. Broken images in README degrade first impressions.

## What Was Fixed
- Replaced `![v3.wttr.in/Bayern](https://v3.wttr.in/Bayern.png)` with `![Example of v3 map view](share/pics/San_Francisco.png)`
- Updated alt text to be descriptive

## Testing Done
- Verified replacement image exists at share/pics/San_Francisco.png
- GitHub README renderer supports relative image paths to repo files
- Static image always available regardless of service status

Closes #1112