### PR TITLE
Micropatch for limnoria compatability

### DIFF
--- a/internal/query/fromrequest.go
+++ b/internal/query/fromrequest.go
@@ -374,6 +374,7 @@ func isPlainTextClient(userAgent string) bool {
 		"xh",
 		"nushell",
 		"zig",
+		"utils.web Limnoria module",
 	}
 
 	ua := strings.ToLower(userAgent)


### PR DESCRIPTION
limnoria(IRC bot, known before as supybot) has the useragent of 'Mozilla/5.0 (compatible; utils.web Limnoria module)'(thx val!) and it triggers the web browser display mode, hopefully this will fix it.