### PR TITLE
Fix one-line precipitation units in imperial formats

### DIFF
--- a/internal/renderer/oneline/render.go
+++ b/internal/renderer/oneline/render.go
@@ -35,7 +35,7 @@ func RenderConditionCode(ctx *RenderContext) string {
 func RenderTemperature(ctx *RenderContext) string {
 	var val float64
 	var unit string
-	if ctx.Options.UseImperial {
+	if usesImperialUnits(ctx) {
 		val, unit = ctx.Data.TempF, "°F"
 	} else {
 		val, unit = ctx.Data.TempC, "°C"
@@ -50,7 +50,7 @@ func RenderTemperature(ctx *RenderContext) string {
 func RenderFeelsLike(ctx *RenderContext) string {
 	var val float64
 	var unit string
-	if ctx.Options.UseImperial {
+	if usesImperialUnits(ctx) {
 		val, unit = ctx.Data.FeelsLikeF, "°F"
 	} else {
 		val, unit = ctx.Data.FeelsLikeC, "°C"
@@ -79,7 +79,7 @@ func RenderWind(ctx *RenderContext) string {
 	case ctx.Options.UseMsForWind:
 		speed = ctx.Data.WindKmph / 3.6
 		unit = "m/s"
-	case ctx.Options.UseImperial:
+	case usesImperialUnits(ctx):
 		speed = ctx.Data.WindMiles
 		unit = "mph"
 	default:
@@ -95,10 +95,14 @@ func RenderHumidity(ctx *RenderContext) string {
 }
 
 func RenderPrecipitation(ctx *RenderContext) string {
-	if ctx.Options.UseImperial || ctx.Options.UseUscs {
-		return fmt.Sprintf("%.1fin", ctx.Data.PrecipInches)
+	if usesImperialUnits(ctx) {
+		return fmt.Sprintf("%.2f in", ctx.Data.PrecipInches)
 	}
 	return fmt.Sprintf("%.1fmm", ctx.Data.PrecipMM)
+}
+
+func usesImperialUnits(ctx *RenderContext) bool {
+	return ctx != nil && ctx.Options != nil && (ctx.Options.UseImperial || ctx.Options.UseUscs)
 }
 
 func RenderPrecipChance(ctx *RenderContext) string {

--- a/internal/renderer/oneline/render_test.go
+++ b/internal/renderer/oneline/render_test.go
@@ -1,0 +1,81 @@
+package oneline
+
+import (
+	"testing"
+
+	"github.com/chubin/wttr.in/internal/domain"
+	"github.com/chubin/wttr.in/internal/options"
+)
+
+var currentWeatherFixture = domain.WeatherRaw(`{
+  "current_condition": [{
+    "FeelsLikeC": "10",
+    "FeelsLikeF": "50",
+    "cloudcover": "25",
+    "humidity": "92",
+    "localObsDateTime": "2026-06-04 12:00",
+    "precipInches": "0.50",
+    "precipMM": "12.7",
+    "pressure": "1012",
+    "temp_C": "18",
+    "temp_F": "64",
+    "uvIndex": "5",
+    "visibility": "10",
+    "weatherCode": "116",
+    "weatherDesc": [{"value": "Partly cloudy"}],
+    "winddir16Point": "S",
+    "winddirDegree": "180",
+    "windspeedKmph": "10",
+    "windspeedMiles": "6"
+  }],
+  "request": [{"query": "Thibodaux", "type": "City"}]
+}`)
+
+func TestRenderPrecipitationUsesInchesForImperialFormats(t *testing.T) {
+	for name, opts := range map[string]*options.Options{
+		"imperial": {Format: "%p", UseImperial: true},
+		"uscs":     {Format: "%p", UseUscs: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			out, err := NewOnelineRenderer().Render(domain.Query{
+				Options: opts,
+				Weather: &currentWeatherFixture,
+			}, nil)
+			if err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+
+			if got, want := string(out.Content), "0.50 in"; got != want {
+				t.Fatalf("Render() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestRenderPrecipitationKeepsMetricDefault(t *testing.T) {
+	out, err := NewOnelineRenderer().Render(domain.Query{
+		Options: &options.Options{Format: "%p"},
+		Weather: &currentWeatherFixture,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	if got, want := string(out.Content), "12.7mm"; got != want {
+		t.Fatalf("Render() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderUSCSUsesImperialWeatherFields(t *testing.T) {
+	out, err := NewOnelineRenderer().Render(domain.Query{
+		Options: &options.Options{Format: "%t %w %p", UseUscs: true},
+		Weather: &currentWeatherFixture,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	if got, want := string(out.Content), "+64\u00b0F ↑6mph 0.50 in"; got != want {
+		t.Fatalf("Render() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1050.

One-line `%p` output now uses inches when imperial/USCS units are active, matching the rest of the one-line weather fields. USCS-only options now also select Fahrenheit and mph for `%t`, `%f`, and `%w`, instead of only affecting precipitation.

## Tests

- `go test ./internal/renderer/oneline`
- `go test ./internal/renderer/oneline ./internal/ip`
- `/opt/homebrew/bin/bash build.sh assets`
- `GOCACHE=/tmp/wttr-1050-gocache go test ./...`
- `make check`
- `git diff --check`
