### PR TITLE
Fix M Weather Unit Parameter and add Test for queryparser

### DIFF
--- a/internal/query/queryparser.go
+++ b/internal/query/queryparser.go
@@ -60,11 +60,16 @@ func (p *strictQueryParser) Parse(ctx context.Context, r *http.Request, ipOpts *
 	}
 
 	// If there is no strong preference for specific units,
-	// use IP-based defaults.
 	if !opts.UseMetric && !opts.UseImperial && !opts.UseUscs {
-		opts.UseMetric = ipOpts.UseMetric
-		opts.UseImperial = ipOpts.UseImperial
-		opts.UseUscs = ipOpts.UseUscs
+		// honor M flag to set metric if no other specified
+		if opts.UseMsForWind {
+			opts.UseMetric = true
+		} else {
+		// else use IP-based defaults.
+			opts.UseMetric = ipOpts.UseMetric
+			opts.UseImperial = ipOpts.UseImperial
+			opts.UseUscs = ipOpts.UseUscs
+		}
 	}
 
 	ApplyAutoFixes(opts)

--- a/internal/query/queryparser_test.go
+++ b/internal/query/queryparser_test.go
@@ -1,0 +1,60 @@
+package query_test
+
+import (
+	"testing"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/chubin/wttr.in/internal/query"
+	"github.com/chubin/wttr.in/internal/options"
+	"github.com/chubin/wttr.in/internal/defs"
+)
+
+func TestWeatherUnits(t *testing.T) {
+	assert := assert.New(t)
+	tests := []struct {
+		parameters   string
+		UseMetric    bool
+		UseImperial  bool
+		UseUscs      bool
+		UseMsForWind bool
+	}{
+		{
+			parameters:   "/Kiev?u",
+			UseMetric:    false,
+			UseImperial:  true,
+			UseUscs:      true,
+			UseMsForWind: false,
+		},
+		{
+			parameters:   "/Kiev?m",
+			UseMetric:    true,
+			UseImperial:  false,
+			UseUscs:      false,
+			UseMsForWind: false,
+		},
+		{
+			parameters:   "/Kiev?M",
+			UseMetric:    true,
+			UseImperial:  false,
+			UseUscs:      false,
+			UseMsForWind: true,
+		},
+	}
+
+	ipOpts := &options.Options{}
+	wttrOps, load_err := defs.LoadDefsFromAssets()
+	assert.NoError(load_err, "LoadDefs")
+	p := query.NewQueryParser(wttrOps)
+	for _, tt := range tests {
+		r := httptest.NewRequest(http.MethodGet, tt.parameters, nil)
+		result, err := p.Parse(nil, r, ipOpts)
+		assert.NoError(err, "NoError: %s", tt.parameters)
+		assert.Equal(result.UseMetric, tt.UseMetric, "UseMetric: %s", tt.parameters)
+		assert.Equal(result.UseImperial, tt.UseImperial, "UseImperial: %s", tt.parameters)
+		assert.Equal(result.UseUscs, tt.UseUscs, "UseUscs: %s", tt.parameters)
+		assert.Equal(result.UseMsForWind, tt.UseMsForWind, "UseMsForWind: %s", tt.parameters)
+	}
+}

--- a/internal/query/queryparser_test.go
+++ b/internal/query/queryparser_test.go
@@ -42,6 +42,13 @@ func TestWeatherUnits(t *testing.T) {
 			UseUscs:      false,
 			UseMsForWind: true,
 		},
+		{
+			parameters:   "/Kiev?Mu",
+			UseMetric:    false,
+			UseImperial:  true,
+			UseUscs:      true,
+			UseMsForWind: true,
+		},
 	}
 
 	ipOpts := &options.Options{}


### PR DESCRIPTION
Aims to fix #1212

Adds a clause to queryparser to first check that if the `M` Weather Unit was specified but no other Weather Unit was specified, that instead of defaulting to ip-based units that metric are used instead.

Additionally adds a test enforcing this behavior.

Note: I was not able to test the full workflow, but since `?Mm` currently works as `?M` previously did, I believe this parsing will have the correct end result.