### PR TITLE
Fix corrupted Persian, Hebrew, and Arabic time-of-day captions

### DIFF
--- a/share/translations/ar/v1.json
+++ b/share/translations/ar/v1.json
@@ -1,7 +1,7 @@
 {
-  "CAPTION_MORNING": "ﺎﻠﻠﻴﻟ",
-  "CAPTION_NOON": "ﺎﻠﻤﺳﺍﺀ",
-  "CAPTION_EVENING": "ﺎﻠﻈﻫﺭ",
-  "CAPTION_NIGHT": "ﺎﻠﺼﺑﺎﺣ",
+  "CAPTION_MORNING": "صباح",
+  "CAPTION_NOON": "ظهر",
+  "CAPTION_EVENING": "مساء",
+  "CAPTION_NIGHT": "ليل",
   "LOCALE": "ar_TN"
 }

--- a/share/translations/fa/v1.json
+++ b/share/translations/fa/v1.json
@@ -1,7 +1,7 @@
 {
-  "CAPTION_MORNING": "حبص",
-  "CAPTION_NOON": "رهظ",
-  "CAPTION_EVENING": "رصع",
-  "CAPTION_NIGHT": "بش",
+  "CAPTION_MORNING": "صبح",
+  "CAPTION_NOON": "ظهر",
+  "CAPTION_EVENING": "عصر",
+  "CAPTION_NIGHT": "شب",
   "LOCALE": "fa_IR"
 }

--- a/share/translations/he/v1.json
+++ b/share/translations/he/v1.json
@@ -1,7 +1,7 @@
 {
-  "CAPTION_MORNING": "רקוב",
-  "CAPTION_NOON": "םוֹיְ",
-  "CAPTION_EVENING": "ברֶעֶ",
-  "CAPTION_NIGHT": "הלָיְלַ",
+  "CAPTION_MORNING": "בוקר",
+  "CAPTION_NOON": "צהריים",
+  "CAPTION_EVENING": "ערב",
+  "CAPTION_NIGHT": "לילה",
   "LOCALE": "he_IL"
 }


### PR DESCRIPTION
Fixes #1091.

The issue title says the Persian text is "displayed wrong," but I pulled the raw JSON and the strings themselves are corrupted at the source, in `share/translations/{fa,he,ar}/v1.json`:

In fa, each word is stored backwards, character by character: `حبص` instead of `صبح` (morning), and so on for all four. Reversing the correct word by hand reproduces the buggy string exactly, so it's baked straight into the data, not a rendering glitch.

In he, same reversal pattern on morning/evening/night (once you strip some stray niqqud/vowel points mixed into the storage), but noon is also just the wrong word: `יוֹם` ("day") reversed, instead of `צהריים` ("noon").

In ar there's a double bug. The four words are pairwise swapped (morning stored the word for night, noon stored the word for evening, and vice versa in both cases), and they're encoded as Arabic Presentation Forms-B code points (the isolated/contextual glyph forms in the U+FE70-FEFF range) instead of standard Arabic letters. Presentation forms don't compose or search correctly outside a rendering context built to expect them.

I replaced all three with plain, correctly-ordered words:

- fa: صبح (morning) / ظهر (noon) / عصر (evening) / شب (night)
- he: בוקר (morning) / צהריים (noon) / ערב (evening) / לילה (night)
- ar: صباح (morning) / ظهر (noon) / مساء (evening) / ليل (night)

Only touched the four caption values in each file. `LOCALE` and formatting are untouched. Validated all three as parseable JSON and checked every character by code point against the intended word: no leftover niqqud, no presentation-form glyphs, no mixing Persian ی into the Arabic strings or vice versa.

One thing worth flagging separately: if these got reversed in the first place because something in the renderer needed pre-reversed strings for a terminal that doesn't do real bidi shaping, this fix will look wrong again in that context. I checked the v1 renderer and the only place it does its own string reversal is the RTL date header (weekday/month via `formatDate`), which is unrelated to these caption keys — the captions are just swapped into a reordered slot layout for RTL, not reversed. So I don't think that risk applies here, but I haven't tested this live against a real RTL terminal, so worth a second look if fa/he/ar output regresses after this merges.
