### PR TITLE
Add RTL directional mark to location output

### DIFF
--- a/internal/localization/localizer.go
+++ b/internal/localization/localizer.go
@@ -101,3 +101,13 @@ func (l10n L10n) WithLang(lang string) L10n {
 	}
 	return New(l10n.localizer, &options.Options{Lang: lang})
 }
+
+// IsRTL reports whether the active language is written right-to-left.
+func (l10n L10n) IsRTL() bool {
+	switch l10n.Lang {
+	case "he", "ar", "fa":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/localization/localizer_test.go
+++ b/internal/localization/localizer_test.go
@@ -1,0 +1,25 @@
+package localization
+
+import "testing"
+
+func TestL10n_IsRTL(t *testing.T) {
+	cases := []struct {
+		lang string
+		want bool
+	}{
+		{"he", true},
+		{"ar", true},
+		{"fa", true},
+		{"en", false},
+		{"de", false},
+		{"ru", false},
+		{"", false},
+	}
+
+	for _, tc := range cases {
+		l10n := L10n{Lang: tc.lang}
+		if got := l10n.IsRTL(); got != tc.want {
+			t.Errorf("L10n{Lang: %q}.IsRTL() = %v, want %v", tc.lang, got, tc.want)
+		}
+	}
+}

--- a/internal/renderer/v1/helpers.go
+++ b/internal/renderer/v1/helpers.go
@@ -7,6 +7,13 @@ import (
 	"github.com/clipperhouse/displaywidth"
 )
 
+// rlm is the Unicode right-to-left mark (U+200F). Prepending it to a
+// string that starts with RTL script tells terminals and other
+// bidi-aware consumers to lay the text out right-to-left instead of
+// guessing from context, which otherwise leaves RTL location names
+// displayed in the wrong visual order (see issue #932).
+const rlm = "‏"
+
 // Safe parsing helpers
 func parseInt(s string) int {
 	if s == "" {

--- a/internal/renderer/v1/renderer.go
+++ b/internal/renderer/v1/renderer.go
@@ -65,7 +65,7 @@ func (r *V1Renderer) Render(query domain.Query, localizer localization.Localizer
 	}
 
 	// Right-to-left support
-	r.rightToLeft = (opts.Lang == "he" || opts.Lang == "ar" || opts.Lang == "fa")
+	r.rightToLeft = l10n.IsRTL()
 
 	// Build caption
 	caption := l10n.Text("CAPTION_WEATHER_REPORT_FOR")
@@ -132,9 +132,16 @@ func (r *V1Renderer) Render(query domain.Query, localizer localization.Localizer
 	if !opts.CurrentOnly {
 
 		if !opts.Quiet && !opts.Superquiet && !opts.NoCity {
+			fullAddress := query.Location.FullAddress
+			if r.rightToLeft {
+				// Prepend a right-to-left mark so terminals render the
+				// location name in the correct visual order instead of
+				// treating it as left-to-right text (issue #932).
+				fullAddress = rlm + fullAddress
+			}
 			sb.WriteString(fmt.Sprintf("%s: %s [%v,%v]\n",
 				l10n.Text("LOCATION"),
-				query.Location.FullAddress, query.Location.Latitude, query.Location.Longitude))
+				fullAddress, query.Location.Latitude, query.Location.Longitude))
 		}
 
 		if opts.Output != "html" && !opts.NoFollowLine {

--- a/internal/renderer/v1/renderer_test.go
+++ b/internal/renderer/v1/renderer_test.go
@@ -132,6 +132,64 @@ func diffLines(got, want string) string {
 	return diff.String()
 }
 
+// TestV1Renderer_LocationRTLMark checks that the "Location:" line is
+// prefixed with a right-to-left mark (U+200F) for RTL languages, and
+// that it stays plain for LTR languages. Without the mark, terminals
+// display RTL location names in the wrong visual order (issue #932).
+func TestV1Renderer_LocationRTLMark(t *testing.T) {
+	weatherRaw, err := loadWeatherRaw("testdata/weather.json")
+	if err != nil {
+		t.Fatalf("failed to load weather data: %v", err)
+	}
+
+	td, err := loadTestData("testdata/testcases.json")
+	if err != nil {
+		t.Fatalf("failed to load test data: %v", err)
+	}
+
+	localizer := translate.NewBundle(assets.FS)
+	renderer := NewV1Renderer()
+
+	cases := []struct {
+		lang    string
+		wantRTL bool
+	}{
+		{"en", false},
+		{"de", false},
+		{"fa", true},
+		{"ar", true},
+		{"he", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.lang, func(t *testing.T) {
+			query := domain.Query{
+				Location: &td.Location,
+				Weather:  weatherRaw,
+				Options:  &options.Options{Lang: tc.lang},
+			}
+
+			output, err := renderer.Render(query, localizer)
+			if err != nil {
+				t.Fatalf("Render failed: %v", err)
+			}
+
+			content := string(output.Content)
+
+			idx := strings.Index(content, td.Location.FullAddress)
+			if idx == -1 {
+				t.Fatalf("output does not contain the location's full address:\n%s", content)
+			}
+
+			hasRLMBefore := strings.HasSuffix(content[:idx], rlm)
+
+			if hasRLMBefore != tc.wantRTL {
+				t.Errorf("lang %q: RLM immediately before location = %v, want %v", tc.lang, hasRLMBefore, tc.wantRTL)
+			}
+		})
+	}
+}
+
 // ===================================================================
 // Helpers
 // ===================================================================

--- a/internal/renderer/v2/block_textualinformation.go
+++ b/internal/renderer/v2/block_textualinformation.go
@@ -16,6 +16,10 @@ import (
 const (
 	dim   = "\033[2m"
 	reset = "\033[0m"
+
+	// rlm is the Unicode right-to-left mark (U+200F). See its use in
+	// buildLocationString and simpleTextualFallback below.
+	rlm = "‏"
 )
 
 func dimLabel(label string) string {
@@ -84,12 +88,12 @@ type section []field
 // textualInformation returns the rich bottom metadata block (data-first)
 func textualInformation(q *domain.Query, loc *domain.Location, opts *options.Options, l10n localization.L10n) string {
 	if q.Weather == nil || len(*q.Weather) == 0 {
-		return simpleTextualFallback(loc)
+		return simpleTextualFallback(loc, l10n.IsRTL())
 	}
 
 	data, err := oneline.ParseCurrentCondition(*q.Weather)
 	if err != nil {
-		return simpleTextualFallback(loc)
+		return simpleTextualFallback(loc, l10n.IsRTL())
 	}
 
 	ctx := &oneline.RenderContext{
@@ -113,7 +117,7 @@ func textualInformation(q *domain.Query, loc *domain.Location, opts *options.Opt
 			{label: l10n.Text("SUNSET"), value: oneline.RenderSunset(ctx)},
 			{label: l10n.Text("DUSK"), value: oneline.RenderDusk(ctx)},
 		},
-		{{label: l10n.Text("LOCATION"), value: buildLocationString(loc)}},
+		{{label: l10n.Text("LOCATION"), value: buildLocationString(loc, l10n.IsRTL())}},
 	}
 
 	return renderSections(sections)
@@ -202,8 +206,13 @@ func buildMainWeatherLine(ctx *oneline.RenderContext) string {
 }
 
 // buildLocationString builds the location line
-func buildLocationString(loc *domain.Location) string {
+func buildLocationString(loc *domain.Location, isRTL bool) string {
 	var b strings.Builder
+	if isRTL {
+		// Right-to-left mark (U+200F): without it, terminals display
+		// an RTL location name in the wrong visual order (issue #932).
+		b.WriteString(rlm)
+	}
 	if loc.FullAddress != "" {
 		b.WriteString(loc.FullAddress)
 	} else {
@@ -220,8 +229,12 @@ func buildLocationString(loc *domain.Location) string {
 }
 
 // simpleTextualFallback
-func simpleTextualFallback(loc *domain.Location) string {
+func simpleTextualFallback(loc *domain.Location, isRTL bool) string {
+	location := loc.Name
+	if isRTL {
+		location = rlm + location
+	}
 	return dimLabel("Weather: ") + "???\n" +
 		dimLabel("Timezone: ") + loc.TimeZone + "\n" +
-		dimLabel("Location: ") + loc.Name + "\n"
+		dimLabel("Location: ") + location + "\n"
 }

--- a/internal/renderer/v2/block_textualinformation_test.go
+++ b/internal/renderer/v2/block_textualinformation_test.go
@@ -1,0 +1,51 @@
+package v2
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chubin/wttr.in/internal/domain"
+)
+
+// TestBuildLocationString_RTLMark checks that the location line gets a
+// leading right-to-left mark (U+200F) for RTL languages, and stays
+// plain otherwise. Without it, terminals display RTL location names
+// in the wrong visual order (issue #932).
+func TestBuildLocationString_RTLMark(t *testing.T) {
+	loc := &domain.Location{
+		Name:        "Talagang",
+		Country:     "Pakistan",
+		FullAddress: "تلہ گنگ, ضلع اٹک, پنجاب, پاکستان",
+		Latitude:    32.9235108,
+		Longitude:   72.4139769,
+	}
+
+	ltr := buildLocationString(loc, false)
+	if strings.HasPrefix(ltr, rlm) {
+		t.Errorf("buildLocationString(isRTL=false) should not start with RLM, got %q", ltr)
+	}
+	if !strings.HasPrefix(ltr, loc.FullAddress) {
+		t.Errorf("buildLocationString(isRTL=false) should start with the address, got %q", ltr)
+	}
+
+	rtlOut := buildLocationString(loc, true)
+	if !strings.HasPrefix(rtlOut, rlm+loc.FullAddress) {
+		t.Errorf("buildLocationString(isRTL=true) should start with RLM + address, got %q", rtlOut)
+	}
+}
+
+// TestSimpleTextualFallback_RTLMark applies the same check to the
+// no-weather-data fallback path.
+func TestSimpleTextualFallback_RTLMark(t *testing.T) {
+	loc := &domain.Location{Name: "تلہ گنگ", TimeZone: "Asia/Karachi"}
+
+	ltr := simpleTextualFallback(loc, false)
+	if strings.Contains(ltr, rlm) {
+		t.Errorf("simpleTextualFallback(isRTL=false) should not contain RLM, got %q", ltr)
+	}
+
+	rtlOut := simpleTextualFallback(loc, true)
+	if !strings.Contains(rtlOut, rlm+loc.Name) {
+		t.Errorf("simpleTextualFallback(isRTL=true) should contain RLM immediately before the location name, got %q", rtlOut)
+	}
+}


### PR DESCRIPTION
Fixes #932.

The Location: line has no RTL mark before the location name, so terminals lay out RTL text (Arabic/Persian/Hebrew, e.g. a Pakistani address that geocodes to Urdu script) as if it were left-to-right and the characters come out in the wrong visual order. Confirmed live against fa.wttr.in/he.wttr.in/ar.wttr.in with curl + a hex dump of the response: the "Location: " label is immediately followed by the RTL bytes with nothing in between.

This is a different bug from #1278 (which fixes corrupted caption strings in the translation files themselves). This one is about the location output, not the captions, and it's untouched by that PR.

Fix: prepend U+200F (right-to-left mark) to the location string when the active language is he/ar/fa, in both the v1 and v2 renderers. Added `L10n.IsRTL()` so both renderers share one place for the RTL language list instead of each keeping its own copy (v1 already had one for its header/day-layout logic; v2 had none at all).

Tests: added a renderer-level test in v1 that checks the Location: line gets the mark for fa/ar/he and not for en/de, and unit tests in v2 for the two functions that build the location string (normal path and the no-weather-data fallback). I don't have a Go toolchain on this machine, so I couldn't run `go test` myself — reviewed the diff carefully and traced the existing golden-file tests to make sure this doesn't touch any of them (the Location: line isn't part of any current golden fixture).
