### PR TITLE
fix: serve localized 404 page for unknown locations

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -9,6 +9,15 @@ var (
 	ErrInvalidCacheEntry      = errors.New("invalid cache entry")
 )
 
+// NotFoundError is a user-facing "unknown location" error carrying a
+// localized message. It is rendered as an HTTP 404 response instead of
+// the generic 500 error page.
+type NotFoundError struct {
+	Message string
+}
+
+func (e *NotFoundError) Error() string { return e.Message }
+
 type Cadre struct {
 	Body []byte
 }

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -15,6 +15,7 @@ import (
 	"github.com/chubin/wttr.in/internal/domain"
 	"github.com/chubin/wttr.in/internal/localization"
 	"github.com/chubin/wttr.in/internal/options"
+	"github.com/chubin/wttr.in/internal/types"
 	"github.com/chubin/wttr.in/internal/util/termutil"
 )
 
@@ -207,10 +208,21 @@ func (s *WeatherService) WeatherHandler(w http.ResponseWriter, r *http.Request) 
 func (s *WeatherService) serveFreshResponse(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	entry, err := s.computeResponse(ctx, r, &TimeTracker{})
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		s.writeComputeError(w, err)
 		return
 	}
 	s.serveFromCache(w, entry)
+}
+
+// writeComputeError renders user-facing errors: unknown locations get
+// their localized 404 page, everything else a generic 500.
+func (s *WeatherService) writeComputeError(w http.ResponseWriter, err error) {
+	var nf *types.NotFoundError
+	if errors.As(err, &nf) {
+		http.Error(w, nf.Message, http.StatusNotFound)
+		return
+	}
+	http.Error(w, err.Error(), http.StatusInternalServerError)
 }
 
 func (s *WeatherService) computeAndStore(ctx context.Context, w http.ResponseWriter, r *http.Request, cacheKey string, overallStart time.Time) {
@@ -226,7 +238,7 @@ func (s *WeatherService) computeAndStore(ctx context.Context, w http.ResponseWri
 	entry, err := s.computeResponse(ctx, r, tracker)
 	if err != nil {
 		s.Cacher.Remove(cacheKey)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		s.writeComputeError(w, err)
 		return
 	}
 
@@ -327,7 +339,11 @@ func (s *WeatherService) computeResponse(
 		if opts.View == "files" || opts.View == "page" {
 			location = &domain.Location{}
 		} else {
-			return nil, fmt.Errorf("location not found: %w", err)
+			// Unknown location: serve the localized 404 page
+			// instead of a generic internal error (#500)
+			l10n := localization.New(s.Localizer, opts)
+			msg := l10n.Text("NOT_FOUND_MESSAGE")
+			return nil, &types.NotFoundError{Message: msg}
 		}
 	}
 	tracker.Add("Geocode location", time.Since(start))


### PR DESCRIPTION
Fixes #500

## Problem

After the Go rewrite, requests for unknown locations no longer show the friendly localized page (NOT_FOUND_MESSAGE - the Oymyakon message discussed in #500). Instead the handler returns an HTTP 500 with the raw error text:

``nlocation not found: ... (HTTP 500)
``

The v1 Python service served a proper HTTP 404 with the localized unknown-location message; this regressed in computeResponse, where any location resolution failure became a generic error that both handlers render via http.Error(w, err.Error(), http.StatusInternalServerError).

## Fix

- computeResponse now returns a typed *types.NotFoundError carrying the localized NOT_FOUND_MESSAGE for the request language (via the existing localizer, English fallback included).
- Both error paths (serveFreshResponse, computeAndStore) route through a new writeComputeError helper: NotFoundError renders as HTTP 404 with the message, everything else keeps the current 500 behavior.
- The iles/page view escape hatch is unchanged.
